### PR TITLE
Add supabase analytics and admin page

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,19 +1,67 @@
 import { useState, useEffect } from 'react';
-import { createClient } from '@/utils/supabase/client'; // Import the new client utility
+import { createClient } from '@/utils/supabase/client';
+import { useRouter } from 'next/router';
 // Assuming you have a global CSS file
 // Try importing from the app directory structure
 import '../app/globals.css'; // Adjust the path if necessary
 
 function MyApp({ Component, pageProps }) {
-    // No longer need SessionContextProvider or manual session state management here.
-    // Middleware and server-side checks handle session refresh and initial state.
-    // Client components can create their own client instance using createClient().
+  const router = useRouter();
 
-    // Optionally, you can still create a client instance here if needed globally,
-    // but it's often cleaner for components/hooks to create their own.
-    // const [supabaseClient] = useState(() => createClient());
+  useEffect(() => {
+    const track = async (url) => {
+      try {
+        const params = new URLSearchParams(url.split('?')[1] || '');
 
-    return <Component {...pageProps} />;
+        let stored = null;
+        const utm = {
+          utm_source: params.get('utm_source'),
+          utm_medium: params.get('utm_medium'),
+          utm_campaign: params.get('utm_campaign')
+        };
+
+        if (utm.utm_source || utm.utm_medium || utm.utm_campaign) {
+          sessionStorage.setItem('utm_params', JSON.stringify(utm));
+          stored = utm;
+        } else {
+          stored = JSON.parse(sessionStorage.getItem('utm_params') || 'null');
+        }
+
+        let location = {};
+        if (process.env.NEXT_PUBLIC_IPINFO_TOKEN) {
+          try {
+            const res = await fetch(`https://ipinfo.io/json?token=${process.env.NEXT_PUBLIC_IPINFO_TOKEN}`);
+            if (res.ok) location = await res.json();
+          } catch (err) {
+            console.error('Failed to fetch location', err);
+          }
+        }
+
+        await fetch('/api/analytics/track', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            url: url.split('?')[0],
+            referrer: document.referrer || null,
+            ...(stored || {}),
+            city: location.city,
+            region: location.region,
+            country: location.country
+          })
+        });
+      } catch (e) {
+        console.error('Analytics track failed', e);
+      }
+    };
+
+    track(window.location.href);
+    router.events.on('routeChangeComplete', track);
+    return () => {
+      router.events.off('routeChangeComplete', track);
+    };
+  }, [router.events]);
+
+  return <Component {...pageProps} />;
 }
 
 export default MyApp; 

--- a/pages/admin/analytics.tsx
+++ b/pages/admin/analytics.tsx
@@ -1,0 +1,118 @@
+import { useEffect, useState } from 'react';
+import { NextPage } from 'next';
+import { useRouter } from 'next/router';
+import { Header } from '../../components/layout/Header';
+import { Footer } from '../../components/layout/Footer';
+import { useProfile } from '../../hooks/useProfile';
+import { createClient } from '@/utils/supabase/client';
+
+interface AnalyticsRow {
+  created_at: string;
+  url: string | null;
+  referrer: string | null;
+  utm_source: string | null;
+  utm_medium: string | null;
+  utm_campaign: string | null;
+  city: string | null;
+  region: string | null;
+  country: string | null;
+}
+
+const AnalyticsAdminPage: NextPage = () => {
+  const router = useRouter();
+  const { loading, session } = useProfile();
+  const [supabase] = useState(() => createClient());
+  const [isAdmin, setIsAdmin] = useState(false);
+  const [data, setData] = useState<AnalyticsRow[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const email = session?.user?.email;
+    if (email) {
+      const admins = ['admin@tayloredinstruction.com', 'evan@tayloredinstruction.com'];
+      setIsAdmin(admins.includes(email));
+    }
+  }, [session]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const since = new Date();
+      since.setMonth(since.getMonth() - 1);
+      const { data, error } = await supabase
+        .from('analytics')
+        .select('*')
+        .gte('created_at', since.toISOString());
+      if (error) {
+        setError(error.message);
+      } else {
+        setData(data || []);
+      }
+    };
+    if (isAdmin) fetchData();
+  }, [isAdmin, supabase]);
+
+  if (loading) {
+    return (
+      <div className="flex flex-col min-h-screen">
+        <Header />
+        <main className="flex-grow container mx-auto px-4 py-8 flex items-center justify-center">
+          <p className="text-lg">Verifying admin access...</p>
+        </main>
+        <Footer />
+      </div>
+    );
+  }
+
+  if (!isAdmin) {
+    if (typeof window !== 'undefined') router.push('/my-account');
+    return null;
+  }
+
+  const totals = {
+    daily: 0,
+    weekly: 0,
+    monthly: data.length
+  };
+  const today = new Date();
+  const oneDay = 24 * 60 * 60 * 1000;
+  data.forEach(row => {
+    const created = new Date(row.created_at).getTime();
+    const diff = today.getTime() - created;
+    if (diff <= oneDay) totals.daily++;
+    if (diff <= 7 * oneDay) totals.weekly++;
+  });
+
+  const sources: Record<string, number> = {};
+  data.forEach(row => {
+    if (row.utm_source) {
+      sources[row.utm_source] = (sources[row.utm_source] || 0) + 1;
+    }
+  });
+  const topSources = Object.entries(sources).sort((a, b) => b[1] - a[1]);
+
+  return (
+    <div className="flex flex-col min-h-screen">
+      <Header />
+      <main className="flex-grow container mx-auto px-4 py-8">
+        <h1 className="text-3xl font-bold mb-6">Site Analytics</h1>
+        {error && <p className="text-red-600 mb-4">{error}</p>}
+        <div className="mb-6">
+          <p className="mb-2">Daily Visitors: {totals.daily}</p>
+          <p className="mb-2">Weekly Visitors: {totals.weekly}</p>
+          <p className="mb-2">Monthly Visitors: {totals.monthly}</p>
+        </div>
+        <div>
+          <h2 className="text-xl font-semibold mb-2">Top Sources</h2>
+          <ul className="list-disc list-inside">
+            {topSources.map(([source, count]) => (
+              <li key={source}>{source}: {count}</li>
+            ))}
+          </ul>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+};
+
+export default AnalyticsAdminPage;

--- a/pages/api/analytics/track.ts
+++ b/pages/api/analytics/track.ts
@@ -1,0 +1,35 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { createApiClientPagesRouter } from '@/utils/supabase/server'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST')
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const supabase = createApiClientPagesRouter(req, res)
+
+  const { url, referrer, utm_source, utm_medium, utm_campaign, city, region, country } = req.body || {}
+
+  const { data: { user } } = await supabase.auth.getUser()
+
+  const { error } = await supabase.from('analytics').insert({
+    url,
+    referrer,
+    utm_source,
+    utm_medium,
+    utm_campaign,
+    city,
+    region,
+    country,
+    user_id: user ? user.id : null,
+    ip_address: (req.headers['x-forwarded-for'] || req.socket.remoteAddress) as string | undefined
+  })
+
+  if (error) {
+    console.error('Analytics insert error', error)
+    return res.status(500).json({ error: error.message })
+  }
+
+  return res.status(200).json({ success: true })
+}

--- a/pages/my-account.tsx
+++ b/pages/my-account.tsx
@@ -25,6 +25,7 @@ const MyAccountPage: NextPage<MyAccountPageProps> = ({ user }) => {
   } = useProfile(user?.id);
   
   const [isAdmin, setIsAdmin] = useState(false);
+  const [showAdmin, setShowAdmin] = useState(false);
 
   useEffect(() => {
     const userEmail = user?.email;
@@ -105,9 +106,24 @@ const MyAccountPage: NextPage<MyAccountPageProps> = ({ user }) => {
                 </>
               )}
               {isAdmin && (
-                <Link href="/admin/instructors" className="text-primary hover:underline block">
-                  Manage Instructors (Admin)
-                </Link>
+                <div>
+                  <button
+                    onClick={() => setShowAdmin(!showAdmin)}
+                    className="text-primary hover:underline block"
+                  >
+                    Admin
+                  </button>
+                  {showAdmin && (
+                    <div className="ml-4 mt-2 space-y-1">
+                      <Link href="/admin/instructors" className="text-primary hover:underline block">
+                        Manage Instructors
+                      </Link>
+                      <Link href="/admin/analytics" className="text-primary hover:underline block">
+                        Analytics
+                      </Link>
+                    </div>
+                  )}
+                </div>
               )}
             </div>
           </div>

--- a/supabase/migrations/20240524000003_create_analytics_table.sql
+++ b/supabase/migrations/20240524000003_create_analytics_table.sql
@@ -1,0 +1,28 @@
+-- Create analytics table to store page views
+CREATE TABLE IF NOT EXISTS public.analytics (
+  id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+  created_at timestamp with time zone DEFAULT now(),
+  url text,
+  referrer text,
+  utm_source text,
+  utm_medium text,
+  utm_campaign text,
+  user_id uuid references auth.users(id),
+  ip_address text,
+  city text,
+  region text,
+  country text
+);
+
+-- Enable RLS
+ALTER TABLE public.analytics ENABLE ROW LEVEL SECURITY;
+
+-- Allow anyone to insert analytics rows
+CREATE POLICY "Analytics insert" ON public.analytics
+FOR INSERT WITH CHECK (true);
+
+-- Allow select only for admins
+CREATE POLICY "Analytics admin select" ON public.analytics
+FOR SELECT USING (
+  (SELECT email FROM auth.users WHERE id = auth.uid()) IN ('admin@tayloredinstruction.com','evan@tayloredinstruction.com')
+);


### PR DESCRIPTION
## Summary
- add new Supabase table and policies for analytics
- record analytics from client in `_app.js`
- expose API endpoint to store page views
- add `/admin/analytics` page for viewing simple stats
- show new Admin dropdown on My Account page

## Testing
- `npm run test` *(fails: many existing ESLint errors)*

------
https://chatgpt.com/codex/tasks/task_b_683b51d9855083238e3f0e10d4f24646