### PR TITLE
Add SMS opt‑out checkbox

### DIFF
--- a/app/actions/sendContactEmail.ts
+++ b/app/actions/sendContactEmail.ts
@@ -20,6 +20,7 @@ const ContactFormSchema = z.object({
     otherLocation: z.string().optional(),
     message: z.string().min(5, 'Message must be at least 5 characters'),
     smsOptIn: z.preprocess((val) => val === 'on', z.boolean()).optional(),
+    smsOptOut: z.preprocess((val) => val === 'on', z.boolean()).optional(),
     contactMethod: z.preprocess((val) => {
         if (typeof val === 'string') return [val];
         if (Array.isArray(val)) return val;
@@ -63,6 +64,7 @@ export async function sendContactEmail(formData: FormData): Promise<SendEmailRes
         otherLocation,
         message,
         smsOptIn,
+        smsOptOut,
         // contactMethod is already destructured via validatedFields.data
     } = validatedFields.data;
     
@@ -84,6 +86,7 @@ export async function sendContactEmail(formData: FormData): Promise<SendEmailRes
                 otherLocation,
                 message,
                 smsOptIn,
+                smsOptOut,
                 contactMethods: contactMethodList
              }),
         });

--- a/app/api/alignment-interest/route.ts
+++ b/app/api/alignment-interest/route.ts
@@ -19,6 +19,7 @@ const AlignmentInterestSchema = z.object({
     agencies: z.array(z.string()).optional(), // Optional array of strings
     message: z.string().optional(),
     smsOptIn: z.boolean().optional(),
+    smsOptOut: z.boolean().optional(),
 }).refine(data => {
     // If hasCertification is 'Yes', agencies array must not be empty (or null/undefined)
     if (data.hasCertification === 'Yes') {
@@ -53,8 +54,9 @@ export async function POST(req: NextRequest) {
             phone, 
             hasCertification, 
             agencies, 
-            message, 
-            smsOptIn 
+            message,
+            smsOptIn,
+            smsOptOut
         } = validatedFields.data; // RESTORED destructuring
 
         // Send email to admin

--- a/components/AlignmentInterestForm.tsx
+++ b/components/AlignmentInterestForm.tsx
@@ -18,6 +18,7 @@ const AlignmentInterestForm: React.FC = () => {
     agencies: [] as string[],
     message: '',
     smsOptIn: false,
+    smsOptOut: false,
   });
   const [status, setStatus] = useState('');
 
@@ -30,6 +31,11 @@ const AlignmentInterestForm: React.FC = () => {
         setFormData(prevState => ({
           ...prevState,
           smsOptIn: checked,
+        }));
+      } else if (name === 'smsOptOut') {
+        setFormData(prevState => ({
+          ...prevState,
+          smsOptOut: checked,
         }));
       } else {
         // Handle agency checkboxes
@@ -83,6 +89,7 @@ const AlignmentInterestForm: React.FC = () => {
           agencies: [],
           message: '',
           smsOptIn: false,
+          smsOptOut: false,
         });
       } else {
         setStatus(`Submission failed: ${result.error || 'Unknown error. Please check your input and try again.'}`);
@@ -200,19 +207,32 @@ const AlignmentInterestForm: React.FC = () => {
       </div>
 
       <div className="flex items-start space-x-2">
-        <Checkbox 
-            id="smsOptIn" 
-            name="smsOptIn" 
+        <Checkbox
+            id="smsOptIn"
+            name="smsOptIn"
             checked={formData.smsOptIn}
-            onCheckedChange={(checked) => handleChange({ target: { name: 'smsOptIn', value: '', type: 'checkbox', checked } } as any)} 
+            onCheckedChange={(checked) => handleChange({ target: { name: 'smsOptIn', value: '', type: 'checkbox', checked } } as any)}
         />
         <div className="grid gap-1.5 leading-none">
             <Label htmlFor="smsOptIn" className="text-sm font-normal text-gray-600">
-                SMS Opt-In (optional)
+                Yes, I agree to receive text messages from Taylored Instruction sent from 360-685-8199.
             </Label>
             <p className="text-xs text-gray-500">
-                By subscribing, you agree to receive SMS notifications from Taylored Instruction. We value your privacy and will never share or sell your phone number. For more details, please review our Privacy Policy at <a href="/privacy-policy/" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">https://tayloredinstruction.com/privacy-policy</a>. Standard message and data rates may apply. You can unsubscribe at any time by replying &quot;STOP&quot; to any of our messages.
+                Message frequency varies and may include appointment reminders, course information, or promotional messages. Message and data rates may apply. Reply STOP at any time to unsubscribe or HELP for assistance. Contact support at 360-685-8199. Please review our <a href="/privacy-policy/" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">Privacy Policy</a> for details on how we handle your information.
             </p>
+        </div>
+      </div>
+      <div className="flex items-start space-x-2 mt-2">
+        <Checkbox
+            id="smsOptOut"
+            name="smsOptOut"
+            checked={formData.smsOptOut}
+            onCheckedChange={(checked) => handleChange({ target: { name: 'smsOptOut', value: '', type: 'checkbox', checked } } as any)}
+        />
+        <div className="grid gap-1.5 leading-none">
+            <Label htmlFor="smsOptOut" className="text-sm font-normal text-gray-600">
+                No, I do not want to receive text messages from Taylored Instruction.
+            </Label>
         </div>
       </div>
 

--- a/components/ContactForm.tsx
+++ b/components/ContactForm.tsx
@@ -115,12 +115,20 @@ export function ContactForm() {
       <div className="flex items-start space-x-2">
         <Checkbox id="smsOptIn" name="smsOptIn" disabled={status.loading} />
         <div className="grid gap-1.5 leading-none">
-           <Label htmlFor="smsOptIn" className="font-normal text-sm">
-              SMS Opt-In (optional)
-           </Label>
-             <p className="text-xs text-muted-foreground">
-              By subscribing, you agree to receive SMS notifications from Taylored Instruction. We value your privacy and will never share or sell your phone number. For more details, please review our <a href="/privacy-policy" className="text-blue-500">Privacy Policy</a>. Standard message and data rates may apply. You can unsubscribe at any time by replying &quot;STOP&quot; to any of our messages.
-             </p>
+          <Label htmlFor="smsOptIn" className="font-normal text-sm">
+            Yes, I agree to receive text messages from Taylored Instruction sent from 360-685-8199.
+          </Label>
+          <p className="text-xs text-muted-foreground">
+            Message frequency varies and may include appointment reminders, course information, or promotional messages. Message and data rates may apply. Reply STOP at any time to unsubscribe or HELP for assistance. Contact support at 360-685-8199. See our <a href="/privacy-policy" className="text-blue-500">Privacy Policy</a> for details on how we handle your information.
+          </p>
+        </div>
+      </div>
+      <div className="flex items-start space-x-2 mt-2">
+        <Checkbox id="smsOptOut" name="smsOptOut" disabled={status.loading} />
+        <div className="grid gap-1.5 leading-none">
+          <Label htmlFor="smsOptOut" className="font-normal text-sm">
+            No, I do not want to receive text messages from Taylored Instruction.
+          </Label>
         </div>
       </div>
       

--- a/emails/AlignmentInterestEmail.tsx
+++ b/emails/AlignmentInterestEmail.tsx
@@ -21,6 +21,7 @@ interface AlignmentInterestEmailProps {
   agencies?: string[];
   message?: string;
   smsOptIn?: boolean;
+  smsOptOut?: boolean;
 }
 
 export default function AlignmentInterestEmail({
@@ -32,6 +33,7 @@ export default function AlignmentInterestEmail({
   agencies,
   message,
   smsOptIn,
+  smsOptOut,
 }: AlignmentInterestEmailProps) {
   return (
     <Html>
@@ -69,7 +71,7 @@ export default function AlignmentInterestEmail({
                 </Text>
               )}
               <Text>
-                <strong>SMS Opt-In:</strong> {smsOptIn ? 'Yes' : 'No'}
+                <strong>SMS Opt-In:</strong> {smsOptIn ? 'Yes' : smsOptOut ? 'No (opted out)' : 'No'}
               </Text>
             </Section>
           </Container>

--- a/emails/ContactFormEmail.tsx
+++ b/emails/ContactFormEmail.tsx
@@ -21,6 +21,7 @@ import {
     otherLocation?: string;
     message: string;
     smsOptIn?: boolean;
+    smsOptOut?: boolean;
     contactMethods?: string[];
   }
   
@@ -33,6 +34,7 @@ import {
     otherLocation,
     message,
     smsOptIn,
+    smsOptOut,
     contactMethods = []
   }) => (
     <Html>
@@ -73,10 +75,12 @@ import {
              <Row>
                 <Column style={messageValueColumn}>{message}</Column>
              </Row>
-             <Row>
-                <Column style={labelColumn}>SMS Opt-In:</Column>
-                <Column style={valueColumn}>{smsOptIn ? 'Yes' : 'No'}</Column>
-             </Row>
+            <Row>
+               <Column style={labelColumn}>SMS Opt-In:</Column>
+                <Column style={valueColumn}>
+                  {smsOptIn ? 'Yes' : smsOptOut ? 'No (opted out)' : 'No'}
+                </Column>
+            </Row>
              <Row>
                 <Column style={labelColumn}>Preferred Contact Method(s):</Column>
                 <Column style={valueColumn}>{contactMethods.join(', ') || 'Not specified'}</Column>


### PR DESCRIPTION
## Summary
- add explicit SMS opt-out option on contact and alignment interest forms
- include opt-out choice in admin notification emails
- handle `smsOptOut` in server actions and API route

## Testing
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_688d5dc35f3c832e8132fba549f7ceb1