### PR TITLE
Refactor analytics integration and improve SEO headers

### DIFF
--- a/app/(marketing)/layout.tsx
+++ b/app/(marketing)/layout.tsx
@@ -1,5 +1,6 @@
 import { ConvexAuthNextjsServerProvider } from "@convex-dev/auth/nextjs/server";
 import { Suspense } from "react";
+import { MarketingTrackerScripts } from "@/components/analytics/MarketingTrackerScripts";
 import { Footer } from "@/components/layout/Footer";
 import { MarketingHeader } from "@/components/layout/MarketingHeader";
 import { ConvexClientProvider } from "@/providers/ConvexClientProvider";
@@ -18,6 +19,7 @@ export default function MarketingLayout({
             <main className="flex-grow">{children}</main>
             <Footer />
           </div>
+          <MarketingTrackerScripts />
         </ConvexClientProvider>
       </ConvexAuthNextjsServerProvider>
     </Suspense>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,7 +3,6 @@ import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import type { Metadata } from "next";
 import { Readex_Pro } from "next/font/google";
-import Script from "next/script";
 import {
   generateJSONLD,
   getOrganizationSchema,
@@ -107,15 +106,6 @@ export default function RootLayout({
   return (
     <html lang="en">
       <head>
-        {/* Preconnect to external domains for performance */}
-        <link href="https://fonts.googleapis.com" rel="preconnect" />
-        <link
-          crossOrigin=""
-          href="https://fonts.gstatic.com"
-          rel="preconnect"
-        />
-        <link href="https://assets.onedollarstats.com" rel="preconnect" />
-
         <script
           dangerouslySetInnerHTML={generateJSONLD(organizationSchema)}
           key="organization-jsonld"
@@ -142,19 +132,6 @@ export default function RootLayout({
       </head>
       <body className={readexPro.variable}>
         {children}
-        <Script
-          src="https://assets.onedollarstats.com/stonks.js"
-          strategy="lazyOnload"
-        />
-        <Script
-          data-persist
-          data-token="e435884d-0dd1-4cd9-b1ae-a5e36a64e5f1"
-          src="https://cdn.visitors.now/v.js"
-          strategy="lazyOnload"
-        />
-        <Script id="apollo-lead-tracking" strategy="lazyOnload">
-          {`function initApollo(){var n=Math.random().toString(36).substring(7),o=document.createElement("script");o.src="https://assets.apollo.io/micro/website-tracker/tracker.iife.js?nocache="+n,o.async=!0,o.defer=!0,o.onload=function(){window.trackingFunctions.onLoad({appId:"6943536a93fbdf001d996156"})},document.head.appendChild(o)}initApollo();`}
-        </Script>
         <Analytics />
         <SpeedInsights />
       </body>

--- a/components/analytics/MarketingTrackerScripts.tsx
+++ b/components/analytics/MarketingTrackerScripts.tsx
@@ -1,0 +1,27 @@
+import Script from "next/script";
+
+/**
+ * Third-party marketing/lead-gen trackers. Loaded only on marketing routes
+ * to avoid main-thread overhead on authenticated app pages.
+ */
+export function MarketingTrackerScripts() {
+  return (
+    <>
+      <Script
+        src="https://assets.onedollarstats.com/stonks.js"
+        strategy="lazyOnload"
+      />
+      <Script
+        data-persist
+        data-token="e435884d-0dd1-4cd9-b1ae-a5e36a64e5f1"
+        src="https://cdn.visitors.now/v.js"
+        strategy="lazyOnload"
+      />
+      <Script
+        id="apollo-lead-tracking"
+        src="/apollo-tracker-init.js"
+        strategy="lazyOnload"
+      />
+    </>
+  );
+}

--- a/components/home/Hero.tsx
+++ b/components/home/Hero.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import Image from "next/image";
 import Link from "next/link";
 import { Button } from "@/components/ui/Button";
@@ -9,9 +7,11 @@ export const Hero = () => (
     <Image
       alt="Life buoy in water - CPR and safety training background"
       className="object-cover"
+      fetchPriority="high"
       fill
       priority
       quality={75}
+      sizes="100vw"
       src="/life-buoy-1.jpeg"
     />
     <div className="absolute inset-0 bg-gray-700/85" />
@@ -20,7 +20,11 @@ export const Hero = () => (
         Safety tailored to your needs.
       </h1>
 
-      <Link href="https://www.hovn.app/tayloredinstruction" target="_blank">
+      <Link
+        href="https://www.hovn.app/tayloredinstruction"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
         <Button className="mt-4 px-8 py-3 text-lg" size="lg">
           Register for Classes
         </Button>

--- a/components/home/ServicesSection.tsx
+++ b/components/home/ServicesSection.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { Heart, LifeBuoy, UserCheck } from "lucide-react";
 import Link from "next/link";
 import type { ComponentProps, ReactNode } from "react";

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -115,8 +115,8 @@ export const Footer = () => {
           </div>
         </div>
 
-        {/* Copyright - Adjusted border and text color */}
-        <div className="border-gray-300 border-t pt-6 text-center text-gray-500 text-xs">
+        {/* Copyright - text-gray-600 for WCAG 4.5:1 contrast on gray-100 */}
+        <div className="border-gray-300 border-t pt-6 text-center text-gray-600 text-xs">
           <p>
             &copy; {new Date().getFullYear()} Taylored Instruction. All Rights
             Reserved.

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -1,6 +1,3 @@
-// This file configures the initialization of PostHog on the client.
-// The added config here will be used whenever a users loads a page in their browser.
-
 // This file configures the initialization of Sentry on the client.
 // The added config here will be used whenever a users loads a page in their browser.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
@@ -12,14 +9,6 @@ import {
 } from "@sentry/nextjs";
 
 export const onRouterTransitionStart = captureRouterTransitionStart;
-
-import posthog from "posthog-js";
-
-// Initialize PostHog
-posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY as string, {
-  api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || "https://us.i.posthog.com",
-  defaults: "2025-05-24",
-});
 
 init({
   dsn: "https://f31f65850f94006f5f71c6a16458e0aa@o4510288242933760.ingest.us.sentry.io/4510288256958464",

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -4,6 +4,8 @@ const nextConfig = {
   poweredByHeader: false, // Remove X-Powered-By header for security
   compress: true, // Enable gzip compression
   cacheComponents: true, // Enable Cache Components (PPR) for Next.js 16
+  // Avoid browser source map requests (404s). Sentry receives maps via build upload.
+  productionBrowserSourceMaps: false,
   images: {
     // domains: ['tayloredinstruction.com', 'www.tayloredinstruction.com'], // Deprecated
     remotePatterns: [
@@ -23,27 +25,49 @@ const nextConfig = {
   },
   // Headers for better SEO and security
   async headers() {
+    const securityHeaders = [
+      {
+        key: "X-DNS-Prefetch-Control",
+        value: "on",
+      },
+      {
+        key: "X-Frame-Options",
+        value: "SAMEORIGIN",
+      },
+      {
+        key: "X-Content-Type-Options",
+        value: "nosniff",
+      },
+      {
+        key: "Referrer-Policy",
+        value: "origin-when-cross-origin",
+      },
+      {
+        key: "Strict-Transport-Security",
+        value: "max-age=31536000; includeSubDomains",
+      },
+      {
+        key: "Cross-Origin-Opener-Policy",
+        value: "same-origin",
+      },
+      {
+        key: "Content-Security-Policy-Report-Only",
+        value: [
+          "default-src 'self'",
+          "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.vercel-insights.com https://*.posthog.com https://us.i.posthog.com https://us-assets.i.posthog.com https://*.sentry.io https://*.ingest.sentry.io https://*.convex.cloud https://assets.apollo.io https://cdn.visitors.now https://assets.onedollarstats.com https://embed.typeform.com https://vancouverusa.chambermaster.com https://*.cal.com",
+          "connect-src 'self' https://*.vercel-insights.com https://*.posthog.com https://us.i.posthog.com https://*.sentry.io https://*.ingest.sentry.io https://*.convex.cloud https://*.convex.cloud https://assets.apollo.io https://cdn.visitors.now https://assets.onedollarstats.com",
+          "img-src 'self' data: blob: https:",
+          "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+          "font-src 'self' https://fonts.gstatic.com",
+          "frame-src 'self' https://cap.so https://www.loom.com https://embed.typeform.com https://*.cal.com",
+        ].join("; "),
+      },
+    ];
+
     return [
       {
         source: "/:path*",
-        headers: [
-          {
-            key: "X-DNS-Prefetch-Control",
-            value: "on",
-          },
-          {
-            key: "X-Frame-Options",
-            value: "SAMEORIGIN",
-          },
-          {
-            key: "X-Content-Type-Options",
-            value: "nosniff",
-          },
-          {
-            key: "Referrer-Policy",
-            value: "origin-when-cross-origin",
-          },
-        ],
+        headers: securityHeaders,
       },
     ];
   },

--- a/next.config.js
+++ b/next.config.js
@@ -55,7 +55,7 @@ const nextConfig = {
         value: [
           "default-src 'self'",
           "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.vercel-insights.com https://*.posthog.com https://us.i.posthog.com https://us-assets.i.posthog.com https://*.sentry.io https://*.ingest.sentry.io https://*.convex.cloud https://assets.apollo.io https://cdn.visitors.now https://assets.onedollarstats.com https://embed.typeform.com https://vancouverusa.chambermaster.com https://*.cal.com",
-          "connect-src 'self' https://*.vercel-insights.com https://*.posthog.com https://us.i.posthog.com https://*.sentry.io https://*.ingest.sentry.io https://*.convex.cloud https://*.convex.cloud https://assets.apollo.io https://cdn.visitors.now https://assets.onedollarstats.com",
+          "connect-src 'self' https://*.vercel-insights.com https://*.posthog.com https://us.i.posthog.com https://*.sentry.io https://*.ingest.sentry.io https://*.convex.cloud https://assets.apollo.io https://cdn.visitors.now https://assets.onedollarstats.com",
           "img-src 'self' data: blob: https:",
           "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
           "font-src 'self' https://fonts.gstatic.com",

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "@types/react": "^19.2.2",
         "@types/react-dom": "^19.2.2",
         "autoprefixer": "^10.4.16",
+        "baseline-browser-mapping": "^2.10.8",
         "dotenv": "^16.6.1",
         "lefthook": "^1.13.6",
         "papaparse": "^5.5.2",
@@ -6413,6 +6414,7 @@
       "version": "2.10.8",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.8.tgz",
       "integrity": "sha512-PCLz/LXGBsNTErbtB6i5u4eLpHeMfi93aUv5duMmj6caNu6IphS4q6UevDnL36sZQv9lrP11dbPKGMaXPwMKfQ==",
+      "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
       },

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@types/react": "^19.2.2",
     "@types/react-dom": "^19.2.2",
     "autoprefixer": "^10.4.16",
+    "baseline-browser-mapping": "^2.10.8",
     "dotenv": "^16.6.1",
     "lefthook": "^1.13.6",
     "papaparse": "^5.5.2",

--- a/public/apollo-tracker-init.js
+++ b/public/apollo-tracker-init.js
@@ -1,0 +1,17 @@
+(() => {
+  const RADIX_36 = 36;
+  const SKIP_PREFIX_LENGTH = 7;
+  const n = Math.random().toString(RADIX_36).substring(SKIP_PREFIX_LENGTH);
+  const o = document.createElement("script");
+  o.src =
+    "https://assets.apollo.io/micro/website-tracker/tracker.iife.js?nocache=" +
+    n;
+  o.async = true;
+  o.defer = true;
+  o.onload = () => {
+    if (typeof window.trackingFunctions !== "undefined") {
+      window.trackingFunctions.onLoad({ appId: "6943536a93fbdf001d996156" });
+    }
+  };
+  document.head.appendChild(o);
+})();


### PR DESCRIPTION
- Removed PostHog initialization from instrumentation-client.ts.
- Added MarketingTrackerScripts component for third-party tracking on marketing routes.
- Updated next.config.js to include enhanced security headers and disabled production source maps.
- Cleaned up layout components by removing unnecessary script tags and preconnect links.
- Introduced apollo-tracker-init.js for Apollo lead tracking.
- Adjusted footer text color for better contrast compliance.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors analytics and third-party tracking by scoping marketing scripts (OneDollarStats, Visitors, Apollo) to the marketing layout via a new `MarketingTrackerScripts` component, removing them from the root layout to reduce overhead on authenticated app pages. It also adds comprehensive security headers (HSTS, COOP, CSP in report-only mode), disables production source maps, removes a duplicate PostHog client-side init, and makes several SEO/performance improvements (Hero image `fetchPriority`/`sizes`, `rel="noopener noreferrer"` on external links, WCAG contrast fix in Footer, removal of unnecessary `"use client"` directives).

- Tracking scripts moved from root `app/layout.tsx` to `components/analytics/MarketingTrackerScripts.tsx`, loaded only on marketing routes
- Inline Apollo tracker extracted to `public/apollo-tracker-init.js` with a `window.trackingFunctions` safety check
- Security headers added in `next.config.js`: HSTS, X-Frame-Options, COOP, and a comprehensive `Content-Security-Policy-Report-Only`
- Duplicate PostHog initialization removed from `instrumentation-client.ts` (still initialized in `providers.tsx`)
- `next-env.d.ts` was modified with an `import` statement — this auto-generated file will be overwritten on the next build and the change should be reverted
- Minor: duplicate `https://*.convex.cloud` in CSP `connect-src` directive

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge after addressing the next-env.d.ts modification, which will be auto-overwritten anyway.
- The changes are well-structured and improve both security and performance. The only real concern is the next-env.d.ts modification which adds an import to an auto-generated file — while it won't cause a production issue (it gets overwritten), it signals a misunderstanding that should be addressed. The CSP duplicate is cosmetic. All other changes are clean improvements.
- Pay close attention to `next-env.d.ts` (should not be committed with manual edits) and `next.config.js` (CSP policy should be validated before promoting from report-only to enforcing).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| app/(marketing)/layout.tsx | Adds MarketingTrackerScripts to scoped marketing layout. Clean integration. |
| app/layout.tsx | Removes third-party tracking scripts and preconnect links from the root layout, deferring to the marketing-scoped component. |
| components/analytics/MarketingTrackerScripts.tsx | New component encapsulating third-party marketing/tracking scripts. Well-structured with lazyOnload strategy. |
| components/home/Hero.tsx | Removes unnecessary "use client", adds fetchPriority/sizes for LCP image, and adds rel="noopener noreferrer" to external link. |
| instrumentation-client.ts | Removes duplicate PostHog initialization. PostHog is still initialized in providers.tsx, so this is safe. |
| next-env.d.ts | Adds import statement to auto-generated file that will be overwritten and may break type references. |
| next.config.js | Adds comprehensive security headers (HSTS, COOP, CSP report-only) and disables production source maps. Minor duplicate in CSP connect-src. |
| public/apollo-tracker-init.js | Extracts inline Apollo tracker script to a standalone file with improved readability and a safety check for window.trackingFunctions. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Root Layout (app/layout.tsx)"] -->|renders| B["Vercel Analytics + SpeedInsights"]
    A -->|renders| C["JSON-LD Structured Data"]
    A -->|nested layout| D["Marketing Layout (app/(marketing)/layout.tsx)"]
    A -->|nested layout| E["App Layout (authenticated)"]
    D -->|renders| F["MarketingTrackerScripts"]
    F --> G["OneDollarStats (lazyOnload)"]
    F --> H["Visitors tracker (lazyOnload)"]
    F --> I["Apollo tracker (lazyOnload)"]
    I -->|loads| J["public/apollo-tracker-init.js"]
    J -->|injects| K["Apollo tracker.iife.js (external)"]

    style F fill:#d4edda,stroke:#28a745
    style E fill:#f0f0f0,stroke:#999
    
    E -.-|"No tracking scripts"| L["Reduced overhead"]
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Anext-env.d.ts%3A3%0A**Auto-generated%20file%20should%20not%20be%20edited**%0A%0AThis%20file%20explicitly%20states%20%22This%20file%20should%20not%20be%20edited%22%20and%20is%20regenerated%20by%20Next.js%20on%20every%20%60next%20dev%60%2C%20%60next%20build%60%2C%20or%20%60next%20typegen%60%20run.%20This%20added%20%60import%60%20line%20will%20be%20overwritten%20automatically.%20Additionally%2C%20adding%20an%20%60import%60%20statement%20converts%20this%20ambient%20declaration%20file%20into%20a%20module%2C%20which%20can%20break%20the%20triple-slash%20reference%20directives%20above%20it%20%28they%20only%20work%20in%20non-module%20files%29.%0A%0ANext.js%20official%20docs%20recommend%20adding%20%60next-env.d.ts%60%20to%20%60.gitignore%60%20and%20using%20%60next%20typegen%60%20to%20regenerate%20it.%20If%20you%20need%20route%20type%20definitions%2C%20they%20should%20be%20referenced%20via%20%60tsconfig.json%60's%20%60include%60%20array%20%28e.g.%2C%20%60.next%2Ftypes%2F**%2F*.ts%60%29%20rather%20than%20modifying%20this%20file.%0A%0A%60%60%60suggestion%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Anext.config.js%3A58%0A**Duplicate%20domain%20in%20%60connect-src%60**%0A%0A%60https%3A%2F%2F*.convex.cloud%60%20appears%20twice%20in%20the%20%60connect-src%60%20directive.%20While%20this%20won't%20cause%20a%20runtime%20error%2C%20it's%20a%20copy-paste%20artifact%20that%20should%20be%20cleaned%20up.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%22connect-src%20'self'%20https%3A%2F%2F*.vercel-insights.com%20https%3A%2F%2F*.posthog.com%20https%3A%2F%2Fus.i.posthog.com%20https%3A%2F%2F*.sentry.io%20https%3A%2F%2F*.ingest.sentry.io%20https%3A%2F%2F*.convex.cloud%20https%3A%2F%2Fassets.apollo.io%20https%3A%2F%2Fcdn.visitors.now%20https%3A%2F%2Fassets.onedollarstats.com%22%2C%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Cursor-black?logo=cursor&logoColor=white"><img alt="Fix All in Cursor" src="https://img.shields.io/badge/Fix_All_in_Cursor-white?logo=cursor&logoColor=black"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: next-env.d.ts
Line: 3

Comment:
**Auto-generated file should not be edited**

This file explicitly states "This file should not be edited" and is regenerated by Next.js on every `next dev`, `next build`, or `next typegen` run. This added `import` line will be overwritten automatically. Additionally, adding an `import` statement converts this ambient declaration file into a module, which can break the triple-slash reference directives above it (they only work in non-module files).

Next.js official docs recommend adding `next-env.d.ts` to `.gitignore` and using `next typegen` to regenerate it. If you need route type definitions, they should be referenced via `tsconfig.json`'s `include` array (e.g., `.next/types/**/*.ts`) rather than modifying this file.

```suggestion
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: next.config.js
Line: 58

Comment:
**Duplicate domain in `connect-src`**

`https://*.convex.cloud` appears twice in the `connect-src` directive. While this won't cause a runtime error, it's a copy-paste artifact that should be cleaned up.

```suggestion
          "connect-src 'self' https://*.vercel-insights.com https://*.posthog.com https://us.i.posthog.com https://*.sentry.io https://*.ingest.sentry.io https://*.convex.cloud https://assets.apollo.io https://cdn.visitors.now https://assets.onedollarstats.com",
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: 3b44ddb</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->