### PR TITLE
Standardize class page layouts and align registration CTAs

### DIFF
--- a/components/AhaInstructorTrainingPageContent.tsx
+++ b/components/AhaInstructorTrainingPageContent.tsx
@@ -1,243 +1,126 @@
-"use client";
+import ClassPageLayout, {
+  ClassPageSection,
+} from "@/components/ClassPageLayout";
 
-import Image from "next/image";
-import type React from "react";
-import CourseRegistrationButton from "@/components/CourseRegistrationButton";
-
-const AhaInstructorTrainingPageContent: React.FC = () => {
+export default function AhaInstructorTrainingPageContent() {
   return (
-    <div>
-      {/* Hero Section with Background Image */}
-      <section className="relative flex min-h-[500px] items-center justify-center md:min-h-[550px]">
-        <div className="absolute inset-0 h-full w-full overflow-hidden">
-          <Image
-            alt="CPR Instructor Training Session"
-            className="brightness-[0.85]"
-            fill
-            priority
-            sizes="100vw"
-            src="/Cpr-Instructor-Image.jpeg"
-            style={{ objectFit: "cover", objectPosition: "center" }}
-          />
-        </div>
-        <div className="absolute inset-0 z-10 bg-gradient-to-r from-black/70 to-black/50" />
-        <div className="container relative z-20 mx-auto px-6 py-20 text-center">
-          <div className="mx-auto max-w-4xl rounded-xl bg-black/30 p-8 backdrop-blur-sm md:p-10">
-            <h1 className="mb-6 font-bold text-4xl text-white md:text-5xl">
-              American Heart Association Instructor Training
-            </h1>
-          </div>
-        </div>
-      </section>
-
-      {/* Main Content Section */}
-      <div className="container mx-auto max-w-4xl px-4 py-12">
-        <h2 className="mb-6 text-center font-bold text-2xl lg:text-3xl">
-          Become an American Heart Association Instructor
-        </h2>
-        <p className="mb-6 text-center text-gray-700 text-lg">
-          Are you passionate about saving lives and teaching others critical
-          lifesaving skills? The American Heart Association (AHA) Instructor
-          courses for Basic Life Support (BLS) and Heartsaver® certifications
-          will equip you with the knowledge and skills to lead AHA courses in
-          your community, workplace, or organization. As an AHA Instructor,
-          you&apos;ll be part of a network dedicated to improving survival rates
-          and providing lifesaving training.
+    <ClassPageLayout
+      courseName="AHA Instructor Training"
+      image={{
+        alt: "CPR instructor training session",
+        src: "/Cpr-Instructor-Image.jpeg",
+      }}
+      registrationUrl="https://www.hovn.app/tayloredinstruction/certifications/aha-bls-instructor-2025/"
+      subtitle="Build the skills to teach AHA BLS or Heartsaver courses in your community, workplace, or organization."
+      title="American Heart Association Instructor Training"
+    >
+      <ClassPageSection title="Course Overview">
+        <p>
+          The AHA Instructor Course trains individuals to effectively teach BLS
+          or Heartsaver courses. Through online and in-person training, you will
+          learn instructional techniques, gain hands-on experience, and receive
+          mentorship to support your success as a certified AHA Instructor.
         </p>
+      </ClassPageSection>
 
-        <CourseRegistrationButton
-          buttonText="View Current Offerings"
-          courseName="AHA Instructor Training"
-          registrationUrl="https://www.hovn.app/tayloredinstruction/certifications/aha-bls-instructor-2025/"
-        />
-
-        <h3 className="mb-3 font-bold text-xl lg:text-2xl">Course Overview</h3>
-        <p className="mb-4 text-gray-700">
-          The AHA Instructor Course is designed to train individuals to
-          effectively teach BLS or Heartsaver® courses. Through a combination of
-          online and in-person training, you&apos;ll learn instructional
-          techniques, gain hands-on experience, and receive mentorship to ensure
-          your success as a certified AHA Instructor.
-        </p>
-
-        <h3 className="mb-3 font-bold text-xl lg:text-2xl">Duration:</h3>
-        <ul className="mb-6 list-inside list-disc space-y-2 text-gray-700">
+      <ClassPageSection title="Duration and Audience">
+        <ul className="list-disc space-y-2 pl-5">
           <li>
-            <strong>Blended Learning:</strong> 2 hours online, 8 hours in-person
-            (excluding monitoring)
+            <strong>Blended Learning:</strong> 2 hours online, 8 hours
+            in-person, excluding monitoring.
           </li>
           <li>
             <strong>Total Commitment:</strong> Approximately 12 hours, including
-            teaching your first course!
+            teaching your first course.
+          </li>
+          <li>
+            <strong>Audience:</strong> Healthcare providers, workplace safety
+            trainers, educators, and anyone passionate about teaching lifesaving
+            skills.
           </li>
         </ul>
+      </ClassPageSection>
 
-        <h3 className="mb-3 font-bold text-xl lg:text-2xl">Audience:</h3>
-        <p className="mb-6 text-gray-700">
-          This course is ideal for healthcare providers, workplace safety
-          trainers, educators, and anyone passionate about teaching lifesaving
-          skills.
-        </p>
-
-        <h3 className="mb-3 font-bold text-xl lg:text-2xl">
-          Steps to Become an AHA Instructor
-        </h3>
-        <h4 className="mb-2 font-semibold text-lg lg:text-xl">
-          1. Complete the Prerequisites
-        </h4>
-        <p className="mb-2 text-gray-700">
-          Before enrolling in the instructor course, you must:
-        </p>
-        <ul className="mb-4 list-inside list-disc space-y-2 text-gray-700">
+      <ClassPageSection title="Steps to Become an AHA Instructor">
+        <ol className="list-decimal space-y-4 pl-5">
           <li>
-            Hold a current, valid AHA Provider certification for the discipline
-            you wish to teach (BLS or Heartsaver®).
+            <strong>Complete the prerequisites.</strong> Hold a current AHA
+            Provider certification for the discipline you wish to teach and
+            request an AHA Instructor Candidate Application through our contact
+            form.
           </li>
           <li>
-            Have an interest in teaching lifesaving skills and a willingness to
-            mentor students.
+            <strong>Enroll in the AHA Instructor Course.</strong> Choose the
+            discipline you want to teach: BLS Instructor or Heartsaver
+            Instructor.
           </li>
           <li>
-            Submit an{" "}
-            <a className="text-primary hover:underline" href="/contact">
-              AHA Instructor Candidate Application request
-            </a>{" "}
-            through our contact form, or email Taylored Instruction at{" "}
-            <a
-              className="text-primary hover:underline"
-              href="mailto:info@tayloredinstruction.com"
-            >
-              info@tayloredinstruction.com
-            </a>
-            .
+            <strong>Complete Online Instructor Essentials.</strong> This
+            self-paced module introduces AHA teaching philosophy and course
+            administration processes.
           </li>
-        </ul>
+          <li>
+            <strong>Attend the in-person instructor training.</strong> Practice
+            teaching, review course materials, and receive feedback from
+            experienced AHA Training Faculty.
+          </li>
+          <li>
+            <strong>Complete a monitoring session.</strong> Teach your first
+            class under supervision so you are prepared to lead courses
+            independently.
+          </li>
+          <li>
+            <strong>Receive your instructor certification.</strong> Once all
+            steps are complete, you will receive your AHA Instructor eCard,
+            valid for two years.
+          </li>
+        </ol>
+      </ClassPageSection>
 
-        <h4 className="mb-2 font-semibold text-lg lg:text-xl">
-          2. Enroll in the AHA Instructor Course
-        </h4>
-        <p className="mb-2 text-gray-700">
-          Choose the discipline you want to teach:
-        </p>
-        <ul className="mb-4 list-inside list-disc space-y-2 text-gray-700">
+      <ClassPageSection title="Certification Details">
+        <ul className="list-disc space-y-2 pl-5">
           <li>
-            <strong>BLS Instructor Course:</strong> Focused on teaching
-            healthcare providers and first responders.
-          </li>
-          <li>
-            <strong>Heartsaver® Instructor Course:</strong> Focused on CPR, AED,
-            and first aid for the general public and workplaces.
-          </li>
-        </ul>
-
-        <h4 className="mb-2 font-semibold text-lg lg:text-xl">
-          3. Complete Online Instructor Essentials
-        </h4>
-        <p className="mb-4 text-gray-700">
-          After registration, you&apos;ll receive access to the AHA Instructor
-          Essentials online module. This self-paced training introduces you to
-          AHA&apos;s teaching philosophy and course administration processes.
-          You must complete this module before attending the in-person session.
-        </p>
-
-        <h4 className="mb-2 font-semibold text-lg lg:text-xl">
-          4. Attend the In-Person Instructor Training
-        </h4>
-        <p className="mb-2 text-gray-700">
-          During the in-person session, you&apos;ll:
-        </p>
-        <ul className="mb-4 list-inside list-disc space-y-2 text-gray-700">
-          <li>
-            Learn to manage a classroom and conduct hands-on skills sessions.
-          </li>
-          <li>
-            Practice teaching and receive feedback from experienced AHA Training
-            Faculty.
-          </li>
-          <li>
-            Review course materials and administrative requirements for AHA
-            Instructors.
-          </li>
-        </ul>
-
-        <h4 className="mb-2 font-semibold text-lg lg:text-xl">
-          5. Complete Monitoring Session
-        </h4>
-        <p className="mb-4 text-gray-700">
-          After your instructor training, you&apos;ll teach your first class
-          under the supervision of an AHA Training Faculty member. This ensures
-          you are confident and prepared to lead AHA courses independently.
-        </p>
-
-        <h4 className="mb-2 font-semibold text-lg lg:text-xl">
-          6. Receive Your Instructor Certification
-        </h4>
-        <p className="mb-6 text-gray-700">
-          Once all steps are complete, you&apos;ll receive your AHA Instructor
-          eCard, valid for two years. You can now teach AHA BLS or Heartsaver®
-          courses as part of a Training Site or Training Center.
-        </p>
-
-        <h3 className="mb-3 font-bold text-xl lg:text-2xl">
-          Certification Details
-        </h3>
-        <ul className="mb-6 list-inside list-disc space-y-2 text-gray-700">
-          <li>
-            <strong>Instructor Certification Validity:</strong> 2 years
+            <strong>Instructor Certification Validity:</strong> 2 years.
           </li>
           <li>
             <strong>Renewal Requirements:</strong> Teach at least four courses
             and complete an Instructor Renewal session every two years.
           </li>
         </ul>
+      </ClassPageSection>
 
-        <h3 className="mb-3 font-bold text-xl lg:text-2xl">
-          Frequently Asked Questions (FAQ)
-        </h3>
-
-        <h4 className="mb-2 font-semibold text-lg lg:text-xl">
-          Who can become an AHA Instructor?
-        </h4>
-        <p className="mb-4 text-gray-700">
-          Anyone with a current AHA Provider certification and a passion for
-          teaching lifesaving skills can become an AHA Instructor.
-        </p>
-
-        <h4 className="mb-2 font-semibold text-lg lg:text-xl">
-          What disciplines can I teach as an Instructor?
-        </h4>
-        <p className="mb-4 text-gray-700">
-          You can choose to teach BLS or Heartsaver® courses, depending on your
-          interest and audience.
-        </p>
-
-        <h4 className="mb-2 font-semibold text-lg lg:text-xl">
-          What is the cost of the Instructor Course?
-        </h4>
-        <p className="mb-4 text-gray-700">
-          Pricing varies depending on the training center and location. Contact
-          us for details and upcoming course dates.
-        </p>
-
-        <h4 className="mb-2 font-semibold text-lg lg:text-xl">
-          What materials will I need as an Instructor?
-        </h4>
-        <p className="mb-4 text-gray-700">
-          You&apos;ll need an AHA Instructor Manual for your chosen discipline,
-          and access to AHA course materials.
-        </p>
-
-        <h4 className="mb-2 font-semibold text-lg lg:text-xl">
-          Can I teach independently?
-        </h4>
-        <p className="mb-4 text-gray-700">
-          Instructors must align with an AHA Training Site or Training Center.
-          This affiliation ensures access to course completion cards and
-          administrative support.
-        </p>
-      </div>
-    </div>
+      <ClassPageSection title="Frequently Asked Questions">
+        <div className="space-y-5">
+          <div>
+            <h3 className="mb-2 font-semibold text-gray-950 text-lg">
+              Who can become an AHA Instructor?
+            </h3>
+            <p>
+              Anyone with a current AHA Provider certification and a passion for
+              teaching lifesaving skills can become an AHA Instructor.
+            </p>
+          </div>
+          <div>
+            <h3 className="mb-2 font-semibold text-gray-950 text-lg">
+              What disciplines can I teach?
+            </h3>
+            <p>
+              You can choose to teach BLS or Heartsaver courses, depending on
+              your interest and audience.
+            </p>
+          </div>
+          <div>
+            <h3 className="mb-2 font-semibold text-gray-950 text-lg">
+              Can I teach independently?
+            </h3>
+            <p>
+              Instructors must align with an AHA Training Site or Training
+              Center. This affiliation ensures access to course completion cards
+              and administrative support.
+            </p>
+          </div>
+        </div>
+      </ClassPageSection>
+    </ClassPageLayout>
   );
-};
-
-export default AhaInstructorTrainingPageContent;
+}

--- a/components/AhaInstructorTrainingPageContent.tsx
+++ b/components/AhaInstructorTrainingPageContent.tsx
@@ -5,6 +5,7 @@ import ClassPageLayout, {
 export default function AhaInstructorTrainingPageContent() {
   return (
     <ClassPageLayout
+      badgeLabel="Instructor Training"
       courseName="AHA Instructor Training"
       image={{
         alt: "CPR instructor training session",

--- a/components/BasicLifeSupportPageContent.tsx
+++ b/components/BasicLifeSupportPageContent.tsx
@@ -1,95 +1,47 @@
-"use client";
+import ClassPageLayout, {
+  ClassPageSection,
+} from "@/components/ClassPageLayout";
 
-import Image from "next/image";
-import Link from "next/link";
-import type React from "react";
-import CourseRegistrationButton from "@/components/CourseRegistrationButton";
-
-const BasicLifeSupportPageContent: React.FC = () => {
+export default function BasicLifeSupportPageContent() {
   return (
-    <div>
-      {/* Hero Section with Background Image */}
-      <section className="relative flex min-h-[500px] items-center justify-center md:min-h-[550px]">
-        <div className="absolute inset-0 h-full w-full overflow-hidden">
-          <Image
-            alt="Basic Life Support Training Session"
-            className="brightness-[0.85]"
-            fill
-            priority
-            sizes="100vw"
-            src="/CPR-Training-Stock-Photo-1-scaled.jpeg"
-            style={{ objectFit: "cover", objectPosition: "center" }}
-          />
-        </div>
-        <div className="absolute inset-0 z-10 bg-gradient-to-r from-black/70 to-black/50" />
-        <div className="container relative z-20 mx-auto px-6 py-20 text-center">
-          <div className="mx-auto max-w-4xl rounded-xl bg-black/30 p-8 backdrop-blur-sm md:p-10">
-            <h1 className="mb-6 font-bold text-4xl text-white md:text-5xl">
-              American Red Cross Basic Life Support
-            </h1>
-          </div>
-        </div>
-      </section>
+    <ClassPageLayout
+      courseName="Basic Life Support"
+      image={{
+        alt: "Basic Life Support training session",
+        src: "/CPR-Training-Stock-Photo-1-scaled.jpeg",
+      }}
+      registrationUrl="https://www.hovn.app/service-providers/tayloredinstruction/offerings"
+      resources={[
+        { href: "/contact", label: "Request Course Fact Sheet" },
+        { href: "/contact", label: "Request Participant Manual" },
+      ]}
+      title="American Red Cross Basic Life Support"
+    >
+      <ClassPageSection title="Course Purpose">
+        <p>
+          The American Red Cross Basic Life Support (BLS) course provides
+          participants with the knowledge and skills they need to assess,
+          recognize and care for patients who are experiencing respiratory
+          arrest, cardiac arrest, airway obstruction or opioid overdose. When a
+          patient experiences a life-threatening emergency, healthcare providers
+          need to act swiftly and promptly.
+        </p>
+        <p>
+          The course emphasizes providing high-quality care and integrating
+          psychomotor skills with critical thinking and problem solving to
+          achieve the best possible patient outcomes.
+        </p>
+      </ClassPageSection>
 
-      {/* Main Content Section */}
-      <div className="container mx-auto max-w-4xl px-4 py-12">
-        {/* Resource Links */}
-        <div className="mb-8 flex flex-col items-center justify-center gap-4 text-center sm:flex-row">
-          <Link
-            className="inline-flex items-center justify-center rounded-md border border-gray-300 bg-white px-4 py-2 font-medium text-gray-700 text-sm shadow-sm transition-colors hover:bg-gray-50"
-            href="/contact"
-          >
-            Request Course Fact Sheet
-          </Link>
-          <Link
-            className="inline-flex items-center justify-center rounded-md border border-gray-300 bg-white px-4 py-2 font-medium text-gray-700 text-sm shadow-sm transition-colors hover:bg-gray-50"
-            href="/contact"
-          >
-            Request Participant Manual
-          </Link>
-        </div>
+      <ClassPageSection title="Course Prerequisites">
+        <p>None.</p>
+      </ClassPageSection>
 
-        {/* Registration Button */}
-        <CourseRegistrationButton
-          buttonText="View Current Offerings"
-          courseName="Basic Life Support"
-          registrationUrl="https://www.hovn.app/service-providers/tayloredinstruction/offerings"
-        />
-
-        {/* Course Purpose Section */}
-        <div className="mb-8 rounded-lg bg-gray-50 p-6 shadow-sm">
-          <h3 className="mb-3 font-bold text-xl lg:text-2xl">Course Purpose</h3>
-          <p className="text-gray-700">
-            The American Red Cross Basic Life Support (BLS) course provides
-            participants with the knowledge and skills they need to assess,
-            recognize and care for patients who are experiencing respiratory
-            arrest, cardiac arrest, airway obstruction or opioid overdose. When
-            a patient experiences a life-threatening emergency, healthcare
-            providers need to act swiftly and promptly. The course emphasizes
-            providing high-quality care and integrating psychomotor skills with
-            critical thinking and problem solving to achieve the best possible
-            patient outcomes.
-          </p>
-        </div>
-
-        {/* Course Prerequisites Section */}
-        <div className="mb-8 rounded-lg bg-gray-50 p-6 shadow-sm">
-          <h3 className="mb-3 font-bold text-xl lg:text-2xl">
-            Course Prerequisites
-          </h3>
-          <p className="text-gray-700">None</p>
-        </div>
-
-        {/* Course Length Section */}
-        <div className="mb-8 rounded-lg bg-gray-50 p-6 shadow-sm">
-          <h3 className="mb-3 font-bold text-xl lg:text-2xl">Course Length</h3>
-          <p className="text-gray-700">
-            Blended Learning: Approximately 2 hours online, 3 hours in-person
-          </p>
-        </div>
-      </div>
-    </div>
+      <ClassPageSection title="Course Length">
+        <p>
+          Blended Learning: Approximately 2 hours online, 3 hours in-person.
+        </p>
+      </ClassPageSection>
+    </ClassPageLayout>
   );
-};
-
-export default BasicLifeSupportPageContent;
+}

--- a/components/BlsPageContent.tsx
+++ b/components/BlsPageContent.tsx
@@ -1,161 +1,112 @@
-import Image from "next/image";
-import CourseRegistrationButton from "@/components/CourseRegistrationButton";
+import ClassPageLayout, {
+  ClassPageSection,
+} from "@/components/ClassPageLayout";
 
 export default function BlsPageContent() {
   return (
-    <div>
-      {/* Hero Section with Background Image */}
-      <section className="relative flex min-h-[500px] items-center justify-center md:min-h-[550px]">
-        <div className="absolute inset-0 h-full w-full overflow-hidden">
-          <Image
-            alt="CPR Training Session" // Preserving original image
-            className="brightness-[0.85]"
-            fill
-            priority
-            sizes="100vw"
-            src="/CPR-Training-Stock-Photo-1-scaled.jpeg"
-            style={{ objectFit: "cover", objectPosition: "20% 51%" }}
-          />
-        </div>
-        <div className="absolute inset-0 z-10 bg-gradient-to-r from-black/70 to-black/50" />
-        <div className="container relative z-20 mx-auto px-6 py-20 text-center">
-          <div className="mx-auto max-w-4xl rounded-xl bg-black/30 p-8 backdrop-blur-sm md:p-10">
-            <h1 className="mb-6 font-bold text-4xl text-white md:text-5xl">
-              American Heart Association Basic Life Support
-            </h1>
+    <ClassPageLayout
+      courseName="BLS Certification"
+      image={{
+        alt: "CPR training session",
+        position: "20% 51%",
+        src: "/CPR-Training-Stock-Photo-1-scaled.jpeg",
+      }}
+      registrationUrl="https://www.hovn.app/tayloredinstruction/certifications/aha-bls-provider-2025/"
+      title="American Heart Association Basic Life Support"
+    >
+      <ClassPageSection title="Course Overview">
+        <p>
+          Our American Heart Association (AHA) Basic Life Support (BLS) course
+          is designed for healthcare professionals and first responders, though
+          anyone is welcome. You&apos;ll learn high-quality CPR for adults,
+          children, and infants, how to use an AED effectively, and essential
+          skills for recognizing and responding to life-threatening emergencies.
+        </p>
+        <p>
+          <strong>Duration:</strong> Approximately 4 hours for in-person, or 2
+          hours for blended learning.
+        </p>
+        <p>
+          <strong>Audience:</strong> Healthcare providers, first responders, and
+          anyone required to have BLS certification as part of their job or
+          studies.
+        </p>
+      </ClassPageSection>
+
+      <ClassPageSection title="Learning Objectives">
+        <p>By the end of this course, participants will be able to:</p>
+        <ul className="list-disc space-y-2 pl-5">
+          <li>Perform high-quality CPR for adults, children, and infants.</li>
+          <li>Use an AED effectively and promptly.</li>
+          <li>Relieve choking in various age groups.</li>
+          <li>Recognize life-threatening emergencies and take action.</li>
+        </ul>
+      </ClassPageSection>
+
+      <ClassPageSection title="Certification Details">
+        <p>
+          Upon successful completion, participants will receive an AHA BLS
+          Provider eCard, valid for two years. To pass, attendees must
+          demonstrate their skills and pass a written test.
+        </p>
+      </ClassPageSection>
+
+      <ClassPageSection title="Course Options">
+        <p>We offer:</p>
+        <ul className="list-disc space-y-2 pl-5">
+          <li>
+            <strong>In-person Training:</strong> Complete all course components
+            in one session.
+          </li>
+          <li>
+            <strong>Blended Learning:</strong> Complete part of the course
+            online at your own pace, followed by an in-person skills session.
+          </li>
+        </ul>
+      </ClassPageSection>
+
+      <ClassPageSection title="Frequently Asked Questions">
+        <div className="space-y-5">
+          <div>
+            <h3 className="mb-2 font-semibold text-gray-950 text-lg">
+              Who needs a BLS certification?
+            </h3>
+            <p>
+              BLS certification is essential for healthcare providers, nursing
+              and medical students, first responders, and anyone needing basic
+              life support knowledge for their career or studies.
+            </p>
+          </div>
+          <div>
+            <h3 className="mb-2 font-semibold text-gray-950 text-lg">
+              How long is the course?
+            </h3>
+            <p>
+              The in-person course typically takes around 4 hours, including
+              breaks and hands-on skills practice.
+            </p>
+          </div>
+          <div>
+            <h3 className="mb-2 font-semibold text-gray-950 text-lg">
+              Are there any prerequisites?
+            </h3>
+            <p>
+              There are no prerequisites to take this course. Prior CPR
+              knowledge can be helpful but is not required.
+            </p>
+          </div>
+          <div>
+            <h3 className="mb-2 font-semibold text-gray-950 text-lg">
+              What do I need to bring?
+            </h3>
+            <p>
+              Please bring a valid photo ID, comfortable clothing for practice
+              sessions, and your completion certificate if taking a blended
+              learning class. All course materials will be provided.
+            </p>
           </div>
         </div>
-      </section>
-
-      {/* Main Content */}
-      <div className="mx-auto max-w-4xl px-4 py-12 sm:px-6 sm:py-16 lg:px-8">
-        <div className="prose prose-lg max-w-none space-y-8">
-          <section>
-            <h2 className="mb-4 font-semibold text-3xl">Course Overview</h2>
-            <p>
-              Our American Heart Association (AHA) Basic Life Support (BLS)
-              course is designed for healthcare professionals and first
-              responders (though anyone is welcome!) who need to know how to
-              perform CPR and other basic cardiovascular life support skills. In
-              this comprehensive training, you&apos;ll learn high-quality CPR
-              for adults, children, and infants, how to use an AED effectively,
-              and essential skills for recognizing and responding to
-              life-threatening emergencies.
-            </p>
-            <p>
-              <strong className="font-semibold">Duration:</strong> Approximately
-              4 hours for in-person, or 2 hours for blended learning
-            </p>
-            <p>
-              <strong className="font-semibold">Audience:</strong> Healthcare
-              providers, first responders, and anyone required to have BLS
-              certification as part of their job or studies.
-            </p>
-            <CourseRegistrationButton
-              buttonText="View Current Offerings"
-              courseName="BLS Certification"
-              registrationUrl="https://www.hovn.app/tayloredinstruction/certifications/aha-bls-provider-2025/"
-            />
-          </section>
-
-          <section>
-            <h2 className="mb-4 font-semibold text-3xl">Learning Objectives</h2>
-            <p>By the end of this course, participants will be able to:</p>
-            <ul className="list-disc space-y-2 pl-6">
-              <li>
-                Perform high-quality CPR for adults, children, and infants
-              </li>
-              <li>Use an AED effectively and promptly</li>
-              <li>Relieve choking in various age groups</li>
-              <li>Recognize life-threatening emergencies and take action</li>
-            </ul>
-          </section>
-
-          <section>
-            <h2 className="mb-4 font-semibold text-3xl">
-              Certification Details
-            </h2>
-            <p>
-              Upon successful completion, participants will receive an AHA BLS
-              Provider eCard, valid for two years. To pass, attendees must
-              demonstrate their skills and pass a written test.
-            </p>
-          </section>
-
-          <section>
-            <h2 className="mb-4 font-semibold text-3xl">Course Options</h2>
-            <p>We offer:</p>
-            <ul className="list-disc space-y-2 pl-6">
-              <li>
-                <strong className="font-semibold">In-person Training:</strong>{" "}
-                Complete all course components in one session.
-              </li>
-              <li>
-                <strong className="font-semibold">Blended Learning:</strong>{" "}
-                Complete part of the course online at your own pace, followed by
-                an in-person skills session.
-              </li>
-            </ul>
-          </section>
-
-          <section>
-            <h2 className="mb-4 font-semibold text-3xl">
-              Frequently Asked Questions (FAQ)
-            </h2>
-            <div className="space-y-6">
-              <div>
-                <h3 className="mb-2 font-semibold text-xl">
-                  Who needs a BLS certification?
-                </h3>
-                <p>
-                  BLS certification is essential for healthcare providers,
-                  nursing and medical students, first responders, and anyone
-                  needing basic life support knowledge for their career or
-                  studies.
-                </p>
-              </div>
-              <div>
-                <h3 className="mb-2 font-semibold text-xl">
-                  How long is the course?
-                </h3>
-                <p>
-                  The in-person course typically takes around 4 hours, including
-                  breaks and hands-on skills practice.
-                </p>
-              </div>
-              <div>
-                <h3 className="mb-2 font-semibold text-xl">
-                  Are there any prerequisites?
-                </h3>
-                <p>
-                  There are no prerequisites to take this course. Prior CPR
-                  knowledge can be helpful but is not required.
-                </p>
-              </div>
-              <div>
-                <h3 className="mb-2 font-semibold text-xl">
-                  What do I need to bring?
-                </h3>
-                <p>
-                  Please bring a valid photo ID, comfortable clothing for
-                  practice sessions, and your completion certificate (if taking
-                  a blended learning class). All course materials will be
-                  provided.
-                </p>
-              </div>
-              <div>
-                <h3 className="mb-2 font-semibold text-xl">
-                  How do I renew my certification?
-                </h3>
-                <p>
-                  BLS certification is valid for two years. You can renew your
-                  certification by taking an AHA BLS Renewal course.
-                </p>
-              </div>
-            </div>
-          </section>
-        </div>
-      </div>
-    </div>
+      </ClassPageSection>
+    </ClassPageLayout>
   );
 }

--- a/components/ClassPageLayout.tsx
+++ b/components/ClassPageLayout.tsx
@@ -1,0 +1,158 @@
+import { ArrowUpRight, FileText } from "lucide-react";
+import Image from "next/image";
+import Link from "next/link";
+import type { ReactNode } from "react";
+import CourseRegistrationButton from "@/components/CourseRegistrationButton";
+import { Button } from "@/components/ui/Button";
+
+type HeroImage = {
+  alt: string;
+  position?: string;
+  src: string;
+};
+
+type ResourceLink = {
+  href: string;
+  label: string;
+};
+
+type SecondaryAction = {
+  href: string;
+  label: string;
+  variant?: "secondary" | "outline";
+};
+
+type ClassPageLayoutProps = {
+  children: ReactNode;
+  courseName: string;
+  image: HeroImage;
+  registrationUrl: string;
+  resources?: ResourceLink[];
+  secondaryActions?: SecondaryAction[];
+  subtitle?: string;
+  title: string;
+};
+
+type ClassPageSectionProps = {
+  children: ReactNode;
+  title: string;
+};
+
+export function ClassPageSection({ children, title }: ClassPageSectionProps) {
+  return (
+    <section className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm md:p-8">
+      <h2 className="mb-4 font-bold text-2xl text-gray-950">{title}</h2>
+      <div className="space-y-4 text-gray-700 leading-relaxed">{children}</div>
+    </section>
+  );
+}
+
+export default function ClassPageLayout({
+  children,
+  courseName,
+  image,
+  registrationUrl,
+  resources = [],
+  secondaryActions = [],
+  subtitle,
+  title,
+}: ClassPageLayoutProps) {
+  return (
+    <div className="bg-white">
+      <section className="relative flex min-h-[430px] items-end overflow-hidden md:min-h-[500px]">
+        <Image
+          alt={image.alt}
+          className="brightness-[0.72]"
+          fill
+          priority
+          sizes="100vw"
+          src={image.src}
+          style={{
+            objectFit: "cover",
+            objectPosition: image.position ?? "center",
+          }}
+        />
+        <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/45 to-black/20" />
+        <div className="container relative z-10 mx-auto max-w-6xl px-4 pt-20 pb-24 sm:px-6 lg:px-8">
+          <div className="max-w-4xl">
+            <p className="mb-4 font-semibold text-sm text-white/80 uppercase tracking-[0.18em]">
+              Certification Course
+            </p>
+            <h1 className="mb-0 max-w-4xl text-balance font-bold text-4xl text-white leading-tight md:text-6xl">
+              {title}
+            </h1>
+            {subtitle ? (
+              <p className="mt-5 max-w-3xl text-lg text-white/90 leading-8">
+                {subtitle}
+              </p>
+            ) : null}
+          </div>
+        </div>
+      </section>
+
+      <section className="-mt-14 relative z-20 mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
+        <div className="rounded-lg border border-gray-200 bg-white p-5 shadow-xl md:p-6">
+          <div className="grid gap-5 lg:grid-cols-[1fr_auto] lg:items-center">
+            <div>
+              <h2 className="mb-2 font-bold text-gray-950 text-xl">
+                Find an upcoming class
+              </h2>
+              <p className="mb-0 text-gray-600">
+                View current dates, locations, and registration details on Hovn.
+              </p>
+            </div>
+            <div className="flex flex-col items-start gap-3 sm:flex-row sm:items-center lg:justify-end">
+              <CourseRegistrationButton
+                buttonClassName="h-12 px-5 py-0 text-base"
+                buttonText="View Current Offerings"
+                className="mb-0"
+                courseName={courseName}
+                registrationUrl={registrationUrl}
+                size="md"
+              />
+              {secondaryActions.map((action) => (
+                <Button
+                  className="h-12 w-full whitespace-nowrap px-5 py-0 text-base sm:w-auto"
+                  href={action.href}
+                  key={action.label}
+                  rel={
+                    action.href.startsWith("http")
+                      ? "noopener noreferrer"
+                      : undefined
+                  }
+                  size="lg"
+                  target={action.href.startsWith("http") ? "_blank" : undefined}
+                  variant={action.variant ?? "secondary"}
+                >
+                  {action.label}
+                  {action.href.startsWith("http") ? (
+                    <ArrowUpRight aria-hidden="true" className="ml-2 size-4" />
+                  ) : null}
+                </Button>
+              ))}
+            </div>
+          </div>
+
+          {resources.length > 0 ? (
+            <div className="mt-5 flex flex-col gap-3 border-gray-200 border-t pt-5 sm:flex-row sm:flex-wrap">
+              {resources.map((resource) => (
+                <Link
+                  className="inline-flex items-center justify-center rounded-md border border-gray-300 bg-white px-4 py-2 font-medium text-gray-700 text-sm transition-colors hover:bg-gray-50"
+                  href={resource.href}
+                  key={resource.label}
+                >
+                  <FileText aria-hidden="true" className="mr-2 size-4" />
+                  {resource.label}
+                </Link>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      </section>
+
+      <main className="mx-auto max-w-4xl px-4 py-14 sm:px-6 sm:py-16 lg:px-8">
+        <div className="space-y-8">{children}</div>
+      </main>
+    </div>
+  );
+}

--- a/components/ClassPageLayout.tsx
+++ b/components/ClassPageLayout.tsx
@@ -23,6 +23,7 @@ type SecondaryAction = {
 };
 
 type ClassPageLayoutProps = {
+  badgeLabel?: string;
   children: ReactNode;
   courseName: string;
   image: HeroImage;
@@ -48,6 +49,7 @@ export function ClassPageSection({ children, title }: ClassPageSectionProps) {
 }
 
 export default function ClassPageLayout({
+  badgeLabel = "Certification Course",
   children,
   courseName,
   image,
@@ -76,7 +78,7 @@ export default function ClassPageLayout({
         <div className="container relative z-10 mx-auto max-w-6xl px-4 pt-20 pb-24 sm:px-6 lg:px-8">
           <div className="max-w-4xl">
             <p className="mb-4 font-semibold text-sm text-white/80 uppercase tracking-[0.18em]">
-              Certification Course
+              {badgeLabel}
             </p>
             <h1 className="mb-0 max-w-4xl text-balance font-bold text-4xl text-white leading-tight md:text-6xl">
               {title}

--- a/components/CourseRegistrationButton.tsx
+++ b/components/CourseRegistrationButton.tsx
@@ -3,6 +3,7 @@
 import { usePostHog } from "posthog-js/react";
 import type React from "react";
 import { Button } from "@/components/ui/Button";
+import { cn } from "@/lib/utils";
 
 type CourseRegistrationButtonProps = {
   courseName: string;
@@ -36,9 +37,12 @@ const CourseRegistrationButton: React.FC<CourseRegistrationButtonProps> = ({
   };
 
   return (
-    <div className={`mb-12 text-center ${className}`}>
+    <div className={cn("mb-12 text-center", className)}>
       <Button
-        className={`shadow-lg transition-shadow duration-200 hover:shadow-xl ${buttonClassName}`}
+        className={cn(
+          "shadow-lg transition-shadow duration-200 hover:shadow-xl",
+          buttonClassName
+        )}
         href={registrationUrl}
         onClick={handleClick}
         rel="noopener noreferrer"

--- a/components/CourseRegistrationButton.tsx
+++ b/components/CourseRegistrationButton.tsx
@@ -8,7 +8,9 @@ type CourseRegistrationButtonProps = {
   courseName: string;
   registrationUrl: string;
   buttonText?: string;
+  buttonClassName?: string;
   className?: string;
+  size?: "sm" | "md" | "lg";
   variant?: "primary" | "secondary" | "outline";
 };
 
@@ -16,7 +18,9 @@ const CourseRegistrationButton: React.FC<CourseRegistrationButtonProps> = ({
   courseName,
   registrationUrl,
   buttonText,
+  buttonClassName = "",
   className = "",
+  size = "lg",
   variant = "primary",
 }) => {
   const posthog = usePostHog();
@@ -34,11 +38,11 @@ const CourseRegistrationButton: React.FC<CourseRegistrationButtonProps> = ({
   return (
     <div className={`mb-12 text-center ${className}`}>
       <Button
-        className="shadow-lg transition-shadow duration-200 hover:shadow-xl"
+        className={`shadow-lg transition-shadow duration-200 hover:shadow-xl ${buttonClassName}`}
         href={registrationUrl}
         onClick={handleClick}
         rel="noopener noreferrer"
-        size="lg"
+        size={size}
         target="_blank"
         variant={variant}
       >

--- a/components/FaCprAedInstructorPageContent.tsx
+++ b/components/FaCprAedInstructorPageContent.tsx
@@ -6,6 +6,7 @@ import ClassPageLayout, {
 export default function FaCprAedInstructorPageContent() {
   return (
     <ClassPageLayout
+      badgeLabel="Instructor Training"
       courseName="First Aid/CPR/AED Instructor"
       image={{
         alt: "CPR instructor training session",

--- a/components/FaCprAedInstructorPageContent.tsx
+++ b/components/FaCprAedInstructorPageContent.tsx
@@ -1,156 +1,83 @@
-"use client";
-
-import Image from "next/image";
 import Link from "next/link";
-import type React from "react";
-import CourseRegistrationButton from "@/components/CourseRegistrationButton";
+import ClassPageLayout, {
+  ClassPageSection,
+} from "@/components/ClassPageLayout";
 
-const FaCprAedInstructorPageContent: React.FC = () => {
+export default function FaCprAedInstructorPageContent() {
   return (
-    <div>
-      {/* Hero Section with Background Image */}
-      <section className="relative flex min-h-[500px] items-center justify-center md:min-h-[550px]">
-        <div className="absolute inset-0 h-full w-full overflow-hidden">
-          <Image
-            alt="CPR Instructor Training Session"
-            className="brightness-[0.85]"
-            fill
-            priority
-            sizes="100vw"
-            src="/Cpr-Instructor-Image.jpeg"
-            style={{ objectFit: "cover", objectPosition: "center" }}
-          />
-        </div>
-        <div className="absolute inset-0 z-10 bg-gradient-to-r from-black/70 to-black/50" />
-        <div className="container relative z-20 mx-auto px-6 py-20 text-center">
-          <div className="mx-auto max-w-4xl rounded-xl bg-black/30 p-8 backdrop-blur-sm md:p-10">
-            <h1 className="mb-6 font-bold text-4xl text-white md:text-5xl">
-              American Red Cross First Aid/CPR/AED Instructor Course
-            </h1>
-          </div>
-        </div>
-      </section>
+    <ClassPageLayout
+      courseName="First Aid/CPR/AED Instructor"
+      image={{
+        alt: "CPR instructor training session",
+        src: "/Cpr-Instructor-Image.jpeg",
+      }}
+      registrationUrl="https://www.hovn.app/tayloredinstruction/certifications/arc-first-aid-cpr-aed-instructor-r25/"
+      resources={[
+        { href: "/contact", label: "Request Course Fact Sheet" },
+        { href: "/contact", label: "Request Instructor Manual" },
+        { href: "/contact", label: "Request Practice Teaching Workbook" },
+      ]}
+      title="American Red Cross First Aid/CPR/AED Instructor Course"
+    >
+      <ClassPageSection title="Course Purpose">
+        <p>
+          The purpose of the American Red Cross FA/CPR/AED Instructor course is
+          to train instructor candidates to teach the basic-level American Red
+          Cross FA/CPR/AED course.
+        </p>
+      </ClassPageSection>
 
-      {/* Main Content Section */}
-      <div className="container mx-auto max-w-4xl px-4 py-12">
-        {/* Resource Links */}
-        <div className="mb-8 flex flex-col items-center justify-center gap-4 text-center sm:flex-row">
+      <ClassPageSection title="Course Prerequisites">
+        <p>
+          FA/CPR/AED Instructor candidates must possess a current basic-level
+          certification in FA/CPR/AED or equivalent.
+        </p>
+      </ClassPageSection>
+
+      <ClassPageSection title="Course Length">
+        <p>
+          The FA/CPR/AED Instructor Course is offered in a blended learning
+          format that includes:
+        </p>
+        <ul className="list-disc space-y-2 pl-5">
+          <li>
+            FA/CPR/AED Instructor Course online session, designed to be
+            completed in approximately 2 hours.
+          </li>
+          <li>
+            FA/CPR/AED Instructor Course in-person session, designed to be
+            completed in approximately 8 hours.
+          </li>
+        </ul>
+      </ClassPageSection>
+
+      <ClassPageSection title="Course Preparation">
+        <p>
+          To prepare for the American Red Cross First Aid/CPR/AED Instructor
+          course, make sure you have strong familiarity with the base skills
+          taught in the Red Cross CPR curriculum. Instructor candidates should
+          be confident performing these skills for others so they can teach them
+          clearly.
+        </p>
+        <p>
+          Each participant must have a copy of the American Red Cross First
+          Aid/CPR/AED Instructor&apos;s Manual. You can request a manual copy
+          using the link at the top of this page, or purchase one from the Red
+          Cross store.
+        </p>
+        <p>
+          You may view all instructor candidate resources on the{" "}
           <Link
-            className="inline-flex items-center justify-center rounded-md border border-gray-300 bg-white px-4 py-2 font-medium text-gray-700 text-sm shadow-sm transition-colors hover:bg-gray-50" // Extracted from HTML
-            href="/contact"
+            className="font-medium text-primary hover:underline"
+            href="https://www.redcrosslearningcenter.org/s/candidate-resources-first-aid-cpr-aed-21"
+            rel="noopener noreferrer"
+            target="_blank"
           >
-            Request Course Fact Sheet
+            Red Cross Learning Center
           </Link>
-          <Link
-            className="inline-flex items-center justify-center rounded-md border border-gray-300 bg-white px-4 py-2 font-medium text-gray-700 text-sm shadow-sm transition-colors hover:bg-gray-50" // Extracted from HTML
-            href="/contact"
-          >
-            Request Instructor Manual
-          </Link>
-          <Link
-            className="inline-flex items-center justify-center rounded-md border border-gray-300 bg-white px-4 py-2 font-medium text-gray-700 text-sm shadow-sm transition-colors hover:bg-gray-50" // Extracted from HTML
-            href="/contact"
-          >
-            Request Practice Teaching Workbook
-          </Link>
-        </div>
-
-        {/* Registration Button */}
-        <CourseRegistrationButton
-          buttonText="View Current Offerings"
-          courseName="First Aid/CPR/AED Instructor"
-          registrationUrl="https://www.hovn.app/tayloredinstruction/certifications/arc-first-aid-cpr-aed-instructor-r25/"
-        />
-
-        {/* Course Purpose Section */}
-        <div className="mb-8 rounded-lg p-6 shadow-sm">
-          <h3 className="mb-3 font-bold text-xl lg:text-2xl">Course Purpose</h3>
-          <p className="text-gray-700">
-            The purpose of the American Red Cross FA/CPR/AED Instructor course
-            is to train instructor candidates to teach the basic-level American
-            Red Cross FA/CPR/AED course.
-          </p>
-        </div>
-
-        {/* Course Prerequisites Section */}
-        <div className="mb-8 rounded-lg p-6 shadow-sm">
-          <h3 className="mb-3 font-bold text-xl lg:text-2xl">
-            Course Prerequisites
-          </h3>
-          <p className="text-gray-700">
-            FA/CPR/AED Instructor candidates must possess a current basic-level
-            certification in FA/CPR/AED or equivalent.
-          </p>
-        </div>
-
-        {/* Course Length Section */}
-        <div className="mb-8 rounded-lg p-6 shadow-sm">
-          <h3 className="mb-3 font-bold text-xl lg:text-2xl">Course Length</h3>
-          <p className="mb-2 text-gray-700">
-            The FA/CPR/AED Instructor Course is offered in a blended learning
-            format that includes:
-          </p>
-          <ul className="list-disc space-y-1 pl-5 text-gray-700">
-            <li>
-              FA/CPR/AED Instructor Course online session—designed to be
-              completed in approximately 2 hours.
-            </li>
-            <li>
-              FA/CPR/AED Instructor Course in-person session—designed to be
-              completed in approximately 8 hours
-            </li>
-          </ul>
-        </div>
-
-        {/* Course Preparation Section */}
-        <div className="mb-8 rounded-lg p-6 shadow-sm">
-          <h3 className="mb-3 font-bold text-xl lg:text-2xl">
-            Course Preparation
-          </h3>
-          <p className="mb-4 text-gray-700">
-            To prepare for the American Red Cross First Aid/CPR/AED Instructor
-            course, please ensure that you have a strong familiarity with the
-            base skills taught in the Red Cross CPR curriculum. Instructor
-            candidates should be confident performing these skills for others,
-            so that they may teach them themselves. In addition, each
-            participant must have a copy of the American Red Cross First
-            Aid/CPR/AED Instructor&#8217;s Manual. You can request a manual copy
-            using the link at the top of this page, or purchase one from the Red
-            Cross store.
-          </p>
-          <p className="text-gray-700">
-            You may view all instructor candidate resources on the{" "}
-            <Link
-              className="font-medium text-primary hover:underline"
-              href="https://www.redcrosslearningcenter.org/s/candidate-resources-first-aid-cpr-aed-21"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Red Cross Learning Center
-            </Link>
-            .
-          </p>
-        </div>
-
-        {/* Interested Section */}
-        <div className="mb-8 rounded-lg p-6 shadow-sm">
-          <h3 className="mb-3 font-bold text-xl lg:text-2xl">
-            Interested in taking a course?
-          </h3>
-          <p className="text-gray-700">
-            Register for a course on our{" "}
-            <Link
-              className="font-medium text-primary hover:underline"
-              href="https://www.hovn.app/tayloredinstruction/certifications/arc-first-aid-cpr-aed-instructor-r25/"
-            >
-              registration page
-            </Link>
-            !
-          </p>
-        </div>
-      </div>
-    </div>
+          .
+        </p>
+      </ClassPageSection>
+    </ClassPageLayout>
   );
-};
-
-export default FaCprAedInstructorPageContent;
+}

--- a/components/FirstAidCprAedPageContent.tsx
+++ b/components/FirstAidCprAedPageContent.tsx
@@ -1,120 +1,55 @@
-"use client";
+import ClassPageLayout, {
+  ClassPageSection,
+} from "@/components/ClassPageLayout";
 
-import Image from "next/image";
-import Link from "next/link";
-import type React from "react";
-import CourseRegistrationButton from "@/components/CourseRegistrationButton";
-
-const FirstAidCprAedPageContent: React.FC = () => {
+export default function FirstAidCprAedPageContent() {
   return (
-    <div>
-      {/* Hero Section with Background Image */}
-      <section className="relative flex min-h-[500px] items-center justify-center md:min-h-[550px]">
-        <div className="absolute inset-0 h-full w-full overflow-hidden">
-          <Image
-            alt="First Aid CPR AED Training Session"
-            className="brightness-[0.85]"
-            fill
-            priority
-            sizes="100vw"
-            src="/CPR-Training-Image.jpeg"
-            style={{ objectFit: "cover", objectPosition: "center" }}
-          />
-        </div>
-        <div className="absolute inset-0 z-10 bg-gradient-to-r from-black/70 to-black/50" />
-        <div className="container relative z-20 mx-auto px-6 py-20 text-center">
-          <div className="mx-auto max-w-4xl rounded-xl bg-black/30 p-8 backdrop-blur-sm md:p-10">
-            <h1 className="mb-6 font-bold text-4xl text-white md:text-5xl">
-              American Red Cross First Aid/CPR/AED
-            </h1>
-          </div>
-        </div>
-      </section>
+    <ClassPageLayout
+      courseName="First Aid/CPR/AED"
+      image={{
+        alt: "First Aid CPR AED training session",
+        src: "/CPR-Training-Image.jpeg",
+      }}
+      registrationUrl="https://www.hovn.app/tayloredinstruction/certifications/arc-adult-and-pediatric-first-aid-cpr-aed-bl-r25/"
+      resources={[
+        { href: "/contact", label: "Request Course Fact Sheet" },
+        { href: "/contact", label: "Request eBook Access Instructions" },
+      ]}
+      title="American Red Cross First Aid/CPR/AED"
+    >
+      <ClassPageSection title="Course Purpose">
+        <p>
+          The American Red Cross First Aid/CPR/AED r.21 program is designed to
+          help participants recognize and respond appropriately to cardiac,
+          breathing and first aid emergencies.
+        </p>
+        <p>
+          The courses in this program teach participants the knowledge and
+          skills needed to give immediate care to an injured or ill person when
+          minutes matter, and to decide whether advanced medical care is needed.
+          This program offers First Aid, CPR and AED courses in traditional
+          classroom or blended learning formats, plus optional skill boosts for
+          specific training needs.
+        </p>
+      </ClassPageSection>
 
-      {/* Main Content Section */}
-      <div className="container mx-auto max-w-4xl px-4 py-12">
-        <div className="mb-8 flex flex-col items-center justify-center gap-4 text-center sm:flex-row">
-          <Link
-            className="inline-flex items-center justify-center rounded-md border border-gray-300 bg-white px-4 py-2 font-medium text-gray-700 text-sm shadow-sm transition-colors hover:bg-gray-50"
-            href="/contact"
-          >
-            Request Course Fact Sheet
-          </Link>
-          <Link
-            className="inline-flex items-center justify-center rounded-md border border-gray-300 bg-white px-4 py-2 font-medium text-gray-700 text-sm shadow-sm transition-colors hover:bg-gray-50"
-            href="/contact"
-          >
-            Request eBook Access Instructions
-          </Link>
-        </div>
+      <ClassPageSection title="Course Prerequisites">
+        <p>
+          There are no prerequisites for the core courses within the First
+          Aid/CPR/AED r.21 program.
+        </p>
+        <p>
+          <strong>Skill Boost Prerequisites:</strong> Participants must have a
+          valid and current certification in First Aid, including FA/CPR/AED,
+          Lifeguarding, EMR, RTE, or equivalent training, to take an optional
+          Skill Boost. Participants may also add skill boosts onto a First
+          Aid/CPR/AED course.
+        </p>
+      </ClassPageSection>
 
-        <CourseRegistrationButton
-          buttonText="View Current Offerings"
-          courseName="First Aid/CPR/AED"
-          registrationUrl="https://www.hovn.app/tayloredinstruction/certifications/arc-adult-and-pediatric-first-aid-cpr-aed-bl-r25/"
-        />
-
-        {/* Course Purpose Section */}
-        <div className="mb-8 rounded-lg bg-gray-50 p-6 shadow-sm">
-          <h3 className="mb-3 font-bold text-xl lg:text-2xl">Course Purpose</h3>
-          <p className="text-gray-700">
-            The American Red Cross First Aid/CPR/AED r.21 program is designed to
-            help participants recognize and respond appropriately to cardiac,
-            breathing and first aid emergencies. The courses in this program
-            teach participants the knowledge and skills needed to give immediate
-            care to an injured or ill person when minutes matter, and to decide
-            whether advanced medical care is needed. This program offers a
-            choice of First Aid, CPR and AED courses in traditional classroom or
-            blended learning (online learning with instructor-led skill session)
-            formats, in addition to optional skill boosts to meet the various
-            training needs of a diverse audience.
-          </p>
-        </div>
-
-        {/* Course Prerequisites Section */}
-        <div className="mb-8 rounded-lg bg-gray-50 p-6 shadow-sm">
-          <h3 className="mb-3 font-bold text-xl lg:text-2xl">
-            Course Prerequisites
-          </h3>
-          <p className="text-gray-700">
-            There are no prerequisites for the core courses within the First
-            Aid/CPR/AED r.21 program.
-            <br />
-            <strong>Skill Boost Prerequisites:</strong> Participants must have a
-            valid and current certification in First Aid (inc. FA/CPR/AED,
-            Lifeguarding, EMR, RTE, etc.) to take an optional Skill Boost.
-            Participants also have the option to add skill boosts onto a First
-            Aid/CPR/AED course.
-          </p>
-        </div>
-
-        {/* Course Length Section */}
-        <div className="mb-8 rounded-lg bg-gray-50 p-6 shadow-sm">
-          <h3 className="mb-3 font-bold text-xl lg:text-2xl">Course Length</h3>
-          <p className="text-gray-700">
-            Approximately 2 hours online, 3 hours in-person
-          </p>
-        </div>
-
-        {/* Interested Section */}
-        <div className="mb-8 rounded-lg bg-gray-50 p-6 shadow-sm">
-          <h3 className="mb-3 font-bold text-xl lg:text-2xl">
-            Interested in taking a course?
-          </h3>
-          <p className="text-gray-700">
-            Search for open class on our{" "}
-            <Link
-              className="font-medium text-primary hover:underline"
-              href="https://www.hovn.app/tayloredinstruction/certifications/arc-adult-and-pediatric-first-aid-cpr-aed-bl-r25/"
-            >
-              registration page
-            </Link>
-            !
-          </p>
-        </div>
-      </div>
-    </div>
+      <ClassPageSection title="Course Length">
+        <p>Approximately 2 hours online, 3 hours in-person.</p>
+      </ClassPageSection>
+    </ClassPageLayout>
   );
-};
-
-export default FirstAidCprAedPageContent;
+}

--- a/components/HeartsaverPageContent.tsx
+++ b/components/HeartsaverPageContent.tsx
@@ -1,176 +1,111 @@
-"use client";
-
-import Image from "next/image";
-import CourseRegistrationButton from "@/components/CourseRegistrationButton";
+import ClassPageLayout, {
+  ClassPageSection,
+} from "@/components/ClassPageLayout";
 
 export default function HeartsaverPageContent() {
   return (
-    <div>
-      {/* Hero Section with Background Image */}
-      <section className="relative flex min-h-[500px] items-center justify-center md:min-h-[550px]">
-        <div className="absolute inset-0 h-full w-full overflow-hidden">
-          <Image
-            alt="CPR Training Photo"
-            className="brightness-[0.85]"
-            fill
-            priority
-            sizes="100vw"
-            src="/CPR-stock-photo-scaled.jpeg"
-            style={{ objectFit: "cover", objectPosition: "54% 66%" }}
-          />
-        </div>
-        <div className="absolute inset-0 z-10 bg-gradient-to-r from-black/70 to-black/50" />
-        <div className="container relative z-20 mx-auto px-6 py-20 text-center">
-          <div className="mx-auto max-w-4xl rounded-xl bg-black/30 p-8 backdrop-blur-sm md:p-10">
-            <h1 className="mb-6 font-bold text-4xl text-white md:text-5xl">
-              American Heart Association Heartsaver® First Aid CPR AED
-            </h1>
+    <ClassPageLayout
+      courseName="Heartsaver Certification"
+      image={{
+        alt: "CPR training class",
+        position: "54% 66%",
+        src: "/CPR-stock-photo-scaled.jpeg",
+      }}
+      registrationUrl="https://www.hovn.app/tayloredinstruction/certifications/aha-heartsaver-first-aid-cpr-aed-2025"
+      title="American Heart Association Heartsaver First Aid CPR AED"
+    >
+      <ClassPageSection title="Course Overview">
+        <p>
+          The American Heart Association Heartsaver courses are designed for
+          anyone with little or no medical training who needs CPR, AED, and
+          first aid knowledge to meet job, regulatory, or personal requirements.
+          This course covers essential lifesaving skills for workplace training
+          or personal preparedness.
+        </p>
+        <p>
+          <strong>Duration:</strong> Approximately 4 hours for in-person, or 1-2
+          hours for blended learning.
+        </p>
+        <p>
+          <strong>Audience:</strong> Teachers, coaches, daycare providers,
+          construction workers, fitness trainers, and anyone who wants to be
+          prepared for an emergency.
+        </p>
+      </ClassPageSection>
+
+      <ClassPageSection title="Learning Objectives">
+        <p>By the end of this course, participants will be able to:</p>
+        <ul className="list-disc space-y-2 pl-5">
+          <li>Perform high-quality CPR for adults, children, and infants.</li>
+          <li>Use an AED effectively and confidently.</li>
+          <li>Manage choking emergencies in various age groups.</li>
+          <li>
+            Provide first aid for common injuries, including cuts, burns,
+            sprains, and more.
+          </li>
+          <li>
+            Recognize and respond to medical emergencies like heart attacks,
+            strokes, and diabetic episodes.
+          </li>
+        </ul>
+      </ClassPageSection>
+
+      <ClassPageSection title="Certification Details">
+        <p>
+          Upon successful completion of the course, participants will receive an
+          AHA Heartsaver certification eCard, valid for two years. To pass,
+          participants must demonstrate the required skills during hands-on
+          practice and pass a brief knowledge check.
+        </p>
+      </ClassPageSection>
+
+      <ClassPageSection title="Course Options">
+        <p>We offer the following formats:</p>
+        <ul className="list-disc space-y-2 pl-5">
+          <li>
+            <strong>In-person Training:</strong> A single, comprehensive session
+            that includes all components of the course.
+          </li>
+          <li>
+            <strong>Blended Learning:</strong> Complete the knowledge portion
+            online at your own pace, followed by an in-person skills session to
+            practice and demonstrate what you&apos;ve learned.
+          </li>
+        </ul>
+      </ClassPageSection>
+
+      <ClassPageSection title="Frequently Asked Questions">
+        <div className="space-y-5">
+          <div>
+            <h3 className="mb-2 font-semibold text-gray-950 text-lg">
+              Who should take a Heartsaver course?
+            </h3>
+            <p>
+              Anyone who needs basic CPR, AED, and first aid knowledge, whether
+              for work, school, or personal preparedness. This course is great
+              for people with no prior experience.
+            </p>
+          </div>
+          <div>
+            <h3 className="mb-2 font-semibold text-gray-950 text-lg">
+              How long does the course take?
+            </h3>
+            <p>
+              The course typically lasts 4 hours in-person or 1-2 hours for
+              blended learning with additional online coursework.
+            </p>
+          </div>
+          <div>
+            <h3 className="mb-2 font-semibold text-gray-950 text-lg">
+              Are there any prerequisites?
+            </h3>
+            <p>
+              No prior experience or medical knowledge is required to enroll in
+              a Heartsaver course.
+            </p>
           </div>
         </div>
-      </section>
-
-      {/* Main Content */}
-      <div className="mx-auto max-w-4xl px-4 py-12 sm:px-6 sm:py-16 lg:px-8">
-        {/* Using prose for typography similar to BLS page */}
-        <div className="prose prose-lg max-w-none space-y-8">
-          <section>
-            <h2 className="mb-4 font-semibold text-3xl">Course Overview</h2>
-            <p>
-              The American Heart Association (AHA) Heartsaver® courses are
-              designed for anyone with little or no medical training who needs
-              CPR, AED, and first aid knowledge to meet job, regulatory, or
-              personal requirements. This user-friendly course covers essential
-              lifesaving skills and is perfect for workplace training or
-              personal preparedness. You&apos;ll learn CPR for adults, children,
-              and infants, proper AED use, and how to manage common first aid
-              scenarios.
-            </p>
-            <p>
-              <strong className="font-semibold">Duration:</strong> Approximately
-              4 hours for in-person, or 1-2 hours for blended learning.
-            </p>
-            <p>
-              <strong className="font-semibold">Audience:</strong> Ideal for
-              teachers, coaches, daycare providers, construction workers,
-              fitness trainers, and anyone who wants to be prepared for an
-              emergency.
-            </p>
-            <CourseRegistrationButton
-              buttonText="View Current Offerings"
-              courseName="Heartsaver Certification"
-              registrationUrl="https://www.hovn.app/tayloredinstruction/certifications/aha-heartsaver-first-aid-cpr-aed-2025"
-            />
-          </section>
-
-          <section>
-            <h2 className="mb-4 font-semibold text-3xl">Learning Objectives</h2>
-            <p>By the end of this course, participants will be able to:</p>
-            <ul className="list-disc space-y-2 pl-6">
-              <li>
-                Perform high-quality CPR for adults, children, and infants.
-              </li>
-              <li>Use an AED effectively and confidently.</li>
-              <li>Manage choking emergencies in various age groups.</li>
-              <li>
-                Provide first aid for common injuries, including cuts, burns,
-                sprains, and more.
-              </li>
-              <li>
-                Recognize and respond to medical emergencies like heart attacks,
-                strokes, and diabetic episodes.
-              </li>
-            </ul>
-          </section>
-
-          <section>
-            <h2 className="mb-4 font-semibold text-3xl">
-              Certification Details
-            </h2>
-            <p>
-              Upon successful completion of the course, participants will
-              receive an AHA Heartsaver® certification eCard, valid for two
-              years. To pass, participants must demonstrate the required skills
-              during hands-on practice and pass a brief knowledge check.
-            </p>
-          </section>
-
-          <section>
-            <h2 className="mb-4 font-semibold text-3xl">Course Options</h2>
-            <p>We offer the following formats:</p>
-            <ul className="list-disc space-y-2 pl-6">
-              <li>
-                <strong className="font-semibold">In-person Training:</strong> A
-                single, comprehensive session that includes all components of
-                the course.
-              </li>
-              <li>
-                <strong className="font-semibold">Blended Learning:</strong>{" "}
-                Complete the knowledge portion online at your own pace, followed
-                by an in-person skills session to practice and demonstrate what
-                you&apos;ve learned.
-              </li>
-            </ul>
-          </section>
-
-          <section>
-            <h2 className="mb-4 font-semibold text-3xl">
-              Frequently Asked Questions (FAQ)
-            </h2>
-            {/* Replicating FAQ structure from HTML */}
-            <div className="space-y-6">
-              <div>
-                <h3 className="mb-2 font-semibold text-xl">
-                  Who should take a Heartsaver® course?
-                </h3>
-                <p>
-                  Anyone who needs basic CPR, AED, and first aid knowledge,
-                  whether for work, school, or personal preparedness. This
-                  course is great for people with no prior experience.
-                </p>
-              </div>
-              <div>
-                <h3 className="mb-2 font-semibold text-xl">
-                  How long does the course take?
-                </h3>
-                <p>
-                  The course typically lasts <strong>4 hours in-person</strong>{" "}
-                  or <strong>1-2 hours for blended learning</strong> (with
-                  additional online coursework).
-                </p>
-              </div>
-              <div>
-                <h3 className="mb-2 font-semibold text-xl">
-                  Are there any prerequisites?
-                </h3>
-                <p>
-                  No prior experience or medical knowledge is required to enroll
-                  in a Heartsaver® course.
-                </p>
-              </div>
-              <div>
-                <h3 className="mb-2 font-semibold text-xl">
-                  What should I bring to the class?
-                </h3>
-                <p>
-                  Bring a valid photo ID, wear comfortable clothing suitable for
-                  practice, and if applicable, bring your online completion
-                  certificate for blended learning. All training materials will
-                  be provided.
-                </p>
-              </div>
-              <div>
-                <h3 className="mb-2 font-semibold text-xl">
-                  How do I renew my certification?
-                </h3>
-                <p>
-                  Heartsaver® certifications are valid for two years. You can
-                  renew by taking another Heartsaver course!
-                </p>
-              </div>
-            </div>
-          </section>
-        </div>
-      </div>
-    </div>
+      </ClassPageSection>
+    </ClassPageLayout>
   );
 }

--- a/components/LifeguardingInstructorPageContent.tsx
+++ b/components/LifeguardingInstructorPageContent.tsx
@@ -5,6 +5,7 @@ import ClassPageLayout, {
 export default function LifeguardingInstructorPageContent() {
   return (
     <ClassPageLayout
+      badgeLabel="Instructor Training"
       courseName="Lifeguarding Instructor"
       image={{
         alt: "Lifeguarding instructor course training",

--- a/components/LifeguardingInstructorPageContent.tsx
+++ b/components/LifeguardingInstructorPageContent.tsx
@@ -1,341 +1,140 @@
-"use client";
+import ClassPageLayout, {
+  ClassPageSection,
+} from "@/components/ClassPageLayout";
 
-import Image from "next/image";
-import type React from "react";
-import { Button } from "@/components/ui/Button";
-
-const LifeguardingInstructorPageContent: React.FC = () => {
+export default function LifeguardingInstructorPageContent() {
   return (
-    <div>
-      {/* Hero Section with Background Image */}
-      <section className="relative flex min-h-[500px] items-center justify-center md:min-h-[550px]">
-        <div className="absolute inset-0 h-full w-full overflow-hidden">
-          <Image
-            alt="Lifeguarding Instructor course training"
-            className="brightness-[0.85]"
-            fill
-            priority
-            sizes="100vw"
-            src="/lifeguard-training.jpeg"
-            style={{ objectFit: "cover", objectPosition: "center" }}
-          />
-        </div>
-        <div className="absolute inset-0 z-10 bg-gradient-to-r from-black/70 to-black/50" />
-        <div className="container relative z-20 mx-auto px-6 py-20 text-center">
-          <div className="mx-auto max-w-4xl rounded-xl bg-black/30 p-8 backdrop-blur-sm md:p-10">
-            <h1 className="mb-6 font-bold text-4xl text-white md:text-5xl">
-              American Red Cross Lifeguarding Instructor Course
-            </h1>
-            <p className="mx-auto max-w-2xl text-white/90">
-              Train to teach Red Cross Lifeguarding courses. Blended learning
-              with online and in-person sessions led by an Instructor Trainer.
-            </p>
-          </div>
-        </div>
-      </section>
-
-      {/* Main Content Section */}
-      <div className="container mx-auto max-w-4xl px-4 py-12">
-        {/* Quick Actions */}
-        <div className="mb-10 flex flex-col items-center justify-center gap-4 text-center sm:flex-row">
-          <Button
-            className="shadow-lg transition-shadow duration-200 hover:shadow-xl"
-            href="https://www.hovn.app/tayloredinstruction/courses/arc-lifeguarding-instructor-blended"
-            size="lg"
-            target="_blank"
-          >
-            View Current Offerings
-          </Button>
-          <Button
-            className="shadow-lg transition-shadow duration-200 hover:shadow-xl"
-            href="/contact"
-            size="lg"
-            variant="secondary"
-          >
-            Host This Course
-          </Button>
-        </div>
-
-        {/* Overview */}
-        <div className="mb-8 rounded-lg p-6 shadow-sm">
-          <h2 className="mb-3 font-bold text-xl lg:text-2xl">
-            Course Overview
-          </h2>
-          <p className="text-gray-700">
-            The Lifeguarding Instructor course prepares instructor candidates to
-            teach American Red Cross Lifeguarding courses. Candidates learn to
-            plan and deliver effective training sessions, evaluate participant
-            skills, and manage course administration using Red Cross program
-            materials.
-          </p>
-        </div>
-
-        {/* Prerequisites */}
-        <div className="mb-8 rounded-lg p-6 shadow-sm">
-          <h3 className="mb-3 font-bold text-xl lg:text-2xl">Prerequisites</h3>
-          <ul className="list-disc space-y-2 pl-5 text-gray-700">
-            <li>Minimum age of 17 by the last day of the course.</li>
-            <li>
-              Possess a current basic-level certification in American Red Cross
-              Lifeguarding (Including Deep Water) with CPR/AED for Professional
-              Rescuers and First Aid.{" "}
-              <span className="italic">
-                Note: r.17 Lifeguarding certification accepted.
-              </span>
-            </li>
-            <li>
-              Obtain instructor and participant course materials before starting
-              the course.
-            </li>
-            <li>
-              Successfully complete the online session of the Lifeguarding
-              Instructor course prior to the precourse session.
-            </li>
-            <li>
-              Successfully complete the prerequisite skill assessment scenario
-              evaluating:
-              <ul className="mt-2 list-[circle] space-y-1 pl-6">
-                <li>Entry</li>
-                <li>Swimming approach</li>
-                <li>Surface dive in deep water (7–10 feet)</li>
-                <li>Passive submerged rescue</li>
-                <li>Rapid extrication (with an assisting rescuer)</li>
-                <li>Rapid assessment</li>
-                <li>Single-rescuer CPR (3 minutes)</li>
-              </ul>
-            </li>
-          </ul>
-        </div>
-
-        {/* Format & Length */}
-        <div className="mb-8 rounded-lg p-6 shadow-sm">
-          <h3 className="mb-3 font-bold text-xl lg:text-2xl">
-            Course Format and Length
-          </h3>
-          <p className="mb-3 text-gray-700">
-            This is a blended learning course consisting of an online session
-            (completed independently) followed by instructor-led classroom and
-            in-water sessions.
-          </p>
-          <ul className="mb-3 list-disc space-y-2 pl-5 text-gray-700">
-            <li>Online session: approximately 2 hours to complete.</li>
-            <li>
-              In-person sessions (including the precourse): 16 hours of
-              instruction time. This does not include breaks or transitions;
-              additional time should be scheduled to accommodate those.
-            </li>
-          </ul>
-          <p className="text-gray-700">
-            Upon successful completion, participants earn the American Red Cross
-            Lifeguarding Instructor certification.
-          </p>
-        </div>
-
-        {/* Course Materials */}
-        <div className="mb-8 rounded-lg p-6 shadow-sm">
-          <h3 className="mb-3 font-bold text-xl lg:text-2xl">
-            Course Materials
-          </h3>
-          <p className="mb-2 text-gray-700">
-            Lifeguarding Instructor candidates should obtain and review the
-            following r.24 materials before attending:
-          </p>
-          <ul className="list-disc space-y-2 pl-5 text-gray-700">
-            <li>
-              Lifeguarding Instructor’s Manual{" "}
-              <span className="italic">
-                (print copy required for in-person sessions)
-              </span>
-            </li>
-            <li>
-              Lifeguarding Instructor’s Deck Book{" "}
-              <span className="italic">(optional)</span>
-            </li>
-            <li>Lifeguarding Manual (digital or print)</li>
-            <li>
-              Lifeguarding course videos{" "}
-              <span className="italic">
-                (via Red Cross Learning Center download, included in the
-                Lifeguarding Course Presentation, or available as a DVD set)
-              </span>
-            </li>
-            <li>
-              Lifeguarding Course Presentation for Instructor-Led Training
-            </li>
-          </ul>
-          <p className="mt-3 text-gray-700 text-sm">
-            Digital materials and video are available in the Red Cross Learning
-            Center. Print materials and kits can be purchased via the Red Cross
-            Store.
-          </p>
-          <p className="mt-2 text-sm">
-            <a
-              className="font-medium text-primary hover:underline"
-              href="https://www.redcrosslearningcenter.org/s/instructor-candidate-resources"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Red Cross Learning Center
-            </a>{" "}
-            ·{" "}
-            <a
-              className="font-medium text-primary hover:underline"
-              href="https://www.redcross.org/store"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Red Cross Store
-            </a>
-          </p>
-        </div>
-
-        {/* What You'll Learn */}
-        <div className="mb-8 rounded-lg p-6 shadow-sm">
-          <h3 className="mb-3 font-bold text-xl lg:text-2xl">
-            What You Will Learn
-          </h3>
-          <ul className="list-disc space-y-2 pl-5 text-gray-700">
-            <li>
-              How to teach and evaluate Red Cross Lifeguarding course
-              participants
-            </li>
-            <li>
-              Effective demonstration, practice, and feedback strategies for
-              in-water skills
-            </li>
-            <li>
-              Using the Instructor Manual, course outlines, and Red Cross
-              administrative tools
-            </li>
-            <li>
-              Setting up safe training environments and managing scenarios
-            </li>
-          </ul>
-        </div>
-
-        {/* Who Should Take */}
-        <div className="mb-8 rounded-lg p-6 shadow-sm">
-          <h3 className="mb-3 font-bold text-xl lg:text-2xl">
-            Who Should Take This Course
-          </h3>
-          <p className="text-gray-700">
-            Experienced lifeguards looking to become instructors at pools,
-            aquatic centers, municipalities, universities, camps, and private
-            facilities.
-          </p>
-        </div>
-
-        {/* Successful Completion */}
-        <div className="mb-8 rounded-lg p-6 shadow-sm">
-          <h3 className="mb-3 font-bold text-xl lg:text-2xl">
-            Successful Completion
-          </h3>
-          <ul className="list-disc space-y-2 pl-5 text-gray-700">
-            <li>
-              Successfully complete the Lifeguarding Instructor Course online
-              session.
-            </li>
-            <li>
-              Successfully complete the prerequisite skill assessment scenario.
-            </li>
-            <li>
-              Successfully complete the skill practice and polish session,
-              demonstrating instructor-level competency in:
-              <ul className="mt-2 list-[circle] space-y-1 pl-6">
-                <li>Entries and approaches</li>
-                <li>Active rescues at the surface</li>
-                <li>Passive rescues at the surface</li>
-                <li>
-                  Passive submerged rescues in shallow, moderate-depth and deep
-                  water
-                </li>
-                <li>Feet-first and head-first surface dives in deep water</li>
-                <li>Rapid extrication using a backboard</li>
-                <li>Putting on gloves with wet hands</li>
-                <li>Two-rescuer CPR with AED for an adult</li>
-                <li>Surveillance and rotation procedures</li>
-                <li>
-                  Spinal motion restriction and extrication in shallow water
-                </li>
-                <li>Multiple-Rescuer Team Response Scenarios</li>
-              </ul>
-            </li>
-            <li>
-              Attend the entire course and actively participate in all class
-              sessions and activities.
-            </li>
-            <li>
-              Successfully complete teaching assignments (small group activities
-              and practice teaching assignments I and II).
-            </li>
-            <li>
-              Demonstrate instructor-level skill competency in all skills.
-            </li>
-            <li>Pass the final written exam with a minimum score of 80%.</li>
-          </ul>
-        </div>
-
-        {/* Certification & Recertification */}
-        <div className="mb-8 rounded-lg p-6 shadow-sm">
-          <h3 className="mb-3 font-bold text-xl lg:text-2xl">
-            Certification & Recertification
-          </h3>
-          <p className="mb-2 text-gray-700">
-            Candidates who successfully complete the course are issued the
-            American Red Cross Lifeguarding Instructor certificate, valid for 2
-            years.
-          </p>
-          <p className="mb-2 text-gray-700">
-            To maintain certification, instructors must successfully complete
-            the Lifeguarding Instructor Recertification blended learning course
-            within the 2-year certification period. If expired, instructors are
-            eligible to participate in recertification for up to 1 year past
-            expiration; this grace period does not extend certification and
-            instructors may not teach during this time.
-          </p>
-          <p className="text-gray-700 text-sm">
-            Courses must be led by an American Red Cross Lifeguarding Instructor
-            Trainer.
-          </p>
-        </div>
-
-        {/* Callouts */}
-        <div className="mb-10 rounded-lg p-6 shadow-sm">
-          <h3 className="mb-3 font-bold text-xl lg:text-2xl">
-            Ready to Get Started?
-          </h3>
-          <p className="mb-4 text-gray-700">
-            Check our current offerings or contact us to host a course at your
-            facility. We regularly schedule classes in Vancouver, WA and San
-            Luis Obispo, CA, and can travel for group trainings.
-          </p>
-          <div className="flex flex-col items-center justify-center gap-4 sm:flex-row">
-            <Button
-              className="shadow-lg transition-shadow duration-200 hover:shadow-xl"
-              href="https://www.hovn.app/tayloredinstruction/courses/arc-lifeguarding-instructor-blended"
-              size="lg"
-              target="_blank"
-            >
-              View Current Offerings
-            </Button>
-            <Button
-              className="shadow-lg transition-shadow duration-200 hover:shadow-xl"
-              href="/contact"
-              size="lg"
-              variant="secondary"
-            >
-              Contact Us
-            </Button>
-          </div>
-        </div>
-
-        <p className="text-gray-500 text-xs">
-          Note: Course content and requirements follow the American Red Cross
-          Lifeguarding Instructor program guidelines.
+    <ClassPageLayout
+      courseName="Lifeguarding Instructor"
+      image={{
+        alt: "Lifeguarding instructor course training",
+        src: "/lifeguard-training.jpeg",
+      }}
+      registrationUrl="https://www.hovn.app/tayloredinstruction/courses/arc-lifeguarding-instructor-blended"
+      secondaryActions={[{ href: "/contact", label: "Host This Course" }]}
+      subtitle="Train to teach Red Cross Lifeguarding courses through blended online and in-person sessions led by an Instructor Trainer."
+      title="American Red Cross Lifeguarding Instructor Course"
+    >
+      <ClassPageSection title="Course Overview">
+        <p>
+          The Lifeguarding Instructor course prepares instructor candidates to
+          teach American Red Cross Lifeguarding courses. Candidates learn to
+          plan and deliver effective training sessions, evaluate participant
+          skills, and manage course administration using Red Cross program
+          materials.
         </p>
-      </div>
-    </div>
-  );
-};
+      </ClassPageSection>
 
-export default LifeguardingInstructorPageContent;
+      <ClassPageSection title="Prerequisites">
+        <ul className="list-disc space-y-2 pl-5">
+          <li>Minimum age of 17 by the last day of the course.</li>
+          <li>
+            Possess a current basic-level certification in American Red Cross
+            Lifeguarding Including Deep Water with CPR/AED for Professional
+            Rescuers and First Aid.
+          </li>
+          <li>
+            Obtain instructor and participant course materials before starting
+            the course.
+          </li>
+          <li>
+            Successfully complete the online session of the Lifeguarding
+            Instructor course prior to the precourse session.
+          </li>
+          <li>
+            Successfully complete the prerequisite skill assessment scenario.
+          </li>
+        </ul>
+      </ClassPageSection>
+
+      <ClassPageSection title="Course Format and Length">
+        <p>
+          This is a blended learning course consisting of an online session
+          completed independently, followed by instructor-led classroom and
+          in-water sessions.
+        </p>
+        <ul className="list-disc space-y-2 pl-5">
+          <li>Online session: approximately 2 hours to complete.</li>
+          <li>
+            In-person sessions, including the precourse, include 16 hours of
+            instruction time. This does not include breaks or transitions.
+          </li>
+        </ul>
+        <p>
+          Upon successful completion, participants earn the American Red Cross
+          Lifeguarding Instructor certification.
+        </p>
+      </ClassPageSection>
+
+      <ClassPageSection title="Course Materials">
+        <p>
+          Lifeguarding Instructor candidates should obtain and review the
+          following r.24 materials before attending:
+        </p>
+        <ul className="list-disc space-y-2 pl-5">
+          <li>Lifeguarding Instructor&apos;s Manual.</li>
+          <li>Lifeguarding Instructor&apos;s Deck Book.</li>
+          <li>Lifeguarding Manual, digital or print.</li>
+          <li>Lifeguarding course videos.</li>
+          <li>Lifeguarding Course Presentation for Instructor-Led Training.</li>
+        </ul>
+      </ClassPageSection>
+
+      <ClassPageSection title="What You Will Learn">
+        <ul className="list-disc space-y-2 pl-5">
+          <li>
+            How to teach and evaluate Red Cross Lifeguarding course
+            participants.
+          </li>
+          <li>
+            Effective demonstration, practice, and feedback strategies for
+            in-water skills.
+          </li>
+          <li>
+            How to use the Instructor Manual, course outlines, and Red Cross
+            administrative tools.
+          </li>
+          <li>
+            How to set up safe training environments and manage scenarios.
+          </li>
+        </ul>
+      </ClassPageSection>
+
+      <ClassPageSection title="Successful Completion">
+        <ul className="list-disc space-y-2 pl-5">
+          <li>
+            Complete the Lifeguarding Instructor Course online session and
+            prerequisite skill assessment scenario.
+          </li>
+          <li>
+            Complete skill practice and polish sessions while demonstrating
+            instructor-level competency.
+          </li>
+          <li>
+            Attend the entire course and actively participate in all class
+            sessions and activities.
+          </li>
+          <li>
+            Successfully complete teaching assignments and pass the final
+            written exam with a minimum score of 80%.
+          </li>
+        </ul>
+      </ClassPageSection>
+
+      <ClassPageSection title="Certification and Recertification">
+        <p>
+          Candidates who successfully complete the course are issued the
+          American Red Cross Lifeguarding Instructor certificate, valid for 2
+          years.
+        </p>
+        <p>
+          To maintain certification, instructors must complete the Lifeguarding
+          Instructor Recertification blended learning course within the 2-year
+          certification period. If expired, instructors are eligible to
+          participate in recertification for up to 1 year past expiration, but
+          this grace period does not extend certification.
+        </p>
+      </ClassPageSection>
+    </ClassPageLayout>
+  );
+}

--- a/components/LifeguardingPageContent.tsx
+++ b/components/LifeguardingPageContent.tsx
@@ -49,6 +49,7 @@ export default function LifeguardingPageContent() {
             <h3 className="mb-2 font-semibold text-gray-950 text-lg">
               Swim-Tread-Swim Sequence
             </h3>
+            <p className="mb-2 text-sm">Complete this sequence within 1 minute, 40 seconds:</p>
             <ol className="list-decimal space-y-2 pl-5 text-sm">
               <li>
                 Jump into the water, fully submerge, resurface, then swim 150

--- a/components/LifeguardingPageContent.tsx
+++ b/components/LifeguardingPageContent.tsx
@@ -1,219 +1,113 @@
-"use client";
-
-import Image from "next/image";
 import Link from "next/link";
-import type React from "react";
-import { Button } from "@/components/ui/Button";
+import ClassPageLayout, {
+  ClassPageSection,
+} from "@/components/ClassPageLayout";
 
-const LifeguardingPageContent: React.FC = () => {
+export default function LifeguardingPageContent() {
   return (
-    <div>
-      {/* Hero Section with Background Image */}
-      <section className="relative flex min-h-[500px] items-center justify-center md:min-h-[550px]">
-        <div className="absolute inset-0 h-full w-full overflow-hidden">
-          <Image
-            alt="Lifeguarding training session"
-            className="brightness-[0.85]"
-            fill
-            priority
-            sizes="100vw"
-            src="/IMG_1872.jpeg"
-            style={{ objectFit: "cover", objectPosition: "center" }}
-          />
-        </div>
-        <div className="absolute inset-0 z-10 bg-gradient-to-r from-black/70 to-black/50" />
-        <div className="container relative z-20 mx-auto px-6 py-20 text-center">
-          <div className="mx-auto max-w-4xl rounded-xl bg-black/30 p-8 backdrop-blur-sm md:p-10">
-            <h1 className="mb-6 font-bold text-4xl text-white md:text-5xl">
-              American Red Cross Lifeguarding
-            </h1>
+    <ClassPageLayout
+      courseName="Lifeguarding"
+      image={{
+        alt: "Lifeguarding training session",
+        src: "/IMG_1872.jpeg",
+      }}
+      registrationUrl="https://www.hovn.app/tayloredinstruction/courses/arc-lifeguarding-blended"
+      resources={[
+        { href: "/contact", label: "Request Course Fact Sheet" },
+        { href: "/contact", label: "Request eBook Access Instructions" },
+      ]}
+      secondaryActions={[
+        {
+          href: "https://www.hovn.app/tayloredinstruction/courses/arc-lifeguarding-recertification-blended",
+          label: "View Recertification Courses",
+        },
+      ]}
+      title="American Red Cross Lifeguarding"
+    >
+      <ClassPageSection title="Course Purpose">
+        <p>
+          The primary purpose of the American Red Cross Lifeguarding program is
+          to provide participants with the knowledge and skills needed to
+          prevent, recognize and respond to aquatic emergencies.
+        </p>
+        <p>
+          Participants also learn to provide professional-level care for
+          breathing and cardiac emergencies, injuries, and sudden illnesses
+          until emergency medical services professionals take over.
+        </p>
+      </ClassPageSection>
+
+      <ClassPageSection title="Course Prerequisites">
+        <p>
+          To participate in the Lifeguarding Including Deep Water course,
+          participants must be at least 15 years old on or before the final
+          scheduled session and successfully complete two prerequisite swimming
+          skills evaluations.
+        </p>
+        <div className="grid gap-6 md:grid-cols-2">
+          <div>
+            <h3 className="mb-2 font-semibold text-gray-950 text-lg">
+              Swim-Tread-Swim Sequence
+            </h3>
+            <ol className="list-decimal space-y-2 pl-5 text-sm">
+              <li>
+                Jump into the water, fully submerge, resurface, then swim 150
+                yards using front crawl, breaststroke, or a combination of both.
+              </li>
+              <li>
+                Maintain position at the surface for 2 minutes by treading water
+                using only the legs.
+              </li>
+              <li>
+                Swim 50 yards using front crawl, breaststroke, or a combination
+                of both.
+              </li>
+            </ol>
+          </div>
+          <div>
+            <h3 className="mb-2 font-semibold text-gray-950 text-lg">
+              Timed Brick Event
+            </h3>
+            <ol className="list-decimal space-y-2 pl-5 text-sm">
+              <li>Starting in the water, swim 20 yards.</li>
+              <li>
+                Submerge to a depth of 7-10 feet to retrieve a 10-pound object.
+              </li>
+              <li>
+                Return to the surface and swim 20 yards on the back while
+                holding the object at the surface with both hands.
+              </li>
+              <li>Exit the water without using a ladder or steps.</li>
+            </ol>
           </div>
         </div>
-      </section>
+      </ClassPageSection>
 
-      {/* Main Content Section */}
-      <div className="container mx-auto max-w-4xl px-4 py-12">
-        {/* PDF Links */}
-        <div className="mb-8 flex flex-col items-center justify-center gap-4 text-center sm:flex-row">
+      <ClassPageSection title="Course Length">
+        <p>
+          Approximately 7 hours online, 25 hours in-person, including breaks.
+        </p>
+      </ClassPageSection>
+
+      <ClassPageSection title="Course Preparation">
+        <p>
+          Make sure you are confident with the prerequisites before class. These
+          evaluations are conducted as soon as the course begins, and
+          participants cannot continue if they are unsuccessful.
+        </p>
+        <p>
+          Complete the eLearning before the first in-person class session. The
+          eLearning is sent in the confirmation email after registration. If you
+          have questions, please{" "}
           <Link
-            className="inline-flex items-center justify-center rounded-md border border-gray-300 bg-white px-4 py-2 font-medium text-gray-700 text-sm shadow-sm transition-colors hover:bg-gray-50" // Extracted from HTML
+            className="font-medium text-primary hover:underline"
             href="/contact"
           >
-            Request Course Fact Sheet
+            contact us
           </Link>
-          <Link
-            className="inline-flex items-center justify-center rounded-md border border-gray-300 bg-white px-4 py-2 font-medium text-gray-700 text-sm shadow-sm transition-colors hover:bg-gray-50" // Extracted from HTML
-            href="/contact"
-          >
-            Request eBook Access Instructions
-          </Link>
-        </div>
-
-        {/* Registration Buttons */}
-        <div className="mb-12 flex flex-col items-center justify-center gap-4 text-center sm:flex-row">
-          <Button
-            className="shadow-lg transition-shadow duration-200 hover:shadow-xl"
-            href="https://www.hovn.app/tayloredinstruction/courses/arc-lifeguarding-blended"
-            size="lg"
-            target="_blank"
-          >
-            View Current Offerings
-          </Button>
-          <Button
-            className="shadow-lg transition-shadow duration-200 hover:shadow-xl"
-            href="https://www.hovn.app/tayloredinstruction/courses/arc-lifeguarding-recertification-blended"
-            size="lg"
-            target="_blank"
-            variant="secondary"
-          >
-            View Recertification Courses
-          </Button>
-        </div>
-
-        {/* Course Purpose Section */}
-        <div className="mb-8 rounded-lg p-6 shadow-sm">
-          <h3 className="mb-3 font-bold text-xl lg:text-2xl">Course Purpose</h3>
-          <p className="mb-4 text-gray-700">
-            The primary purpose of the courses in the American Red Cross
-            Lifeguarding program is to provide participants with the knowledge
-            and skills needed to:
-          </p>
-          <ul className="list-disc space-y-2 pl-5 text-gray-700">
-            <li>Prevent, recognize and respond to aquatic emergencies.</li>
-            <li>
-              Provide professional-level care for breathing and cardiac
-              emergencies, injuries, and sudden illnesses until emergency
-              medical services (EMS) professionals take over.
-            </li>
-          </ul>
-        </div>
-
-        {/* Course Prerequisites Section */}
-        <div className="mb-8 rounded-lg p-6 shadow-sm">
-          <h3 className="mb-3 font-bold text-xl lg:text-2xl">
-            Course Prerequisites
-          </h3>
-          <p className="mb-4 text-gray-700">
-            To participate in the Lifeguarding (Including Deep Water) course,
-            participants must:
-          </p>
-          <ul className="mb-6 list-disc space-y-2 pl-5 text-gray-700">
-            <li>
-              Be at least 15 years old on or before the final scheduled session
-              of the Lifeguarding course.
-            </li>
-            <li>
-              Successfully complete the two prerequisite swimming skills
-              evaluations:
-            </li>
-          </ul>
-          <div className="grid gap-6 md:grid-cols-2">
-            <div>
-              <h4 className="mb-2 font-semibold text-gray-800">
-                Prerequisite 1:
-              </h4>
-              <p className="mb-2 text-gray-700">
-                Complete a swim-tread-swim sequence without stopping to rest:
-              </p>
-              <ul className="list-decimal space-y-1 pl-5 text-gray-700 text-sm">
-                <li>
-                  Jump into the water and totally submerge, resurface then swim
-                  150 yards (3 full, down and back laps in a typical 25 yard
-                  pool) using the front crawl, breaststroke or a combination of
-                  both. (Swimming on the back or side is not permitted. Swim
-                  goggles are allowed)
-                </li>
-                <li>
-                  Maintain position at the surface of the water for 2 minutes by
-                  treading water using only the legs
-                </li>
-                <li>
-                  Swim 50 yards (1 full lap) using the front crawl, breaststroke
-                  or a combination of both
-                </li>
-              </ul>
-            </div>
-            <div>
-              <h4 className="mb-2 font-semibold text-gray-800">
-                Prerequisite 2:
-              </h4>
-              <p className="mb-2 text-gray-700">
-                Complete a timed event within 1 minute, 40 seconds:
-              </p>
-              <ul className="list-decimal space-y-1 pl-5 text-gray-700 text-sm">
-                <li>
-                  Starting in the water, swim 20 yards. (The face may be in or
-                  out of the water. Swim goggles are not allowed).
-                </li>
-                <li>
-                  Submerge to a depth of 7 - 10 feet to retrieve a 10-pound
-                  object.
-                </li>
-                <li>
-                  Return to the surface and swim 20 yards on the back to return
-                  to the starting point, holding the object at the surface with
-                  both hands and keeping the face out at or near the surface.
-                </li>
-                <li>Exit the water without using a ladder or steps.</li>
-              </ul>
-            </div>
-          </div>
-        </div>
-
-        {/* Course Length Section */}
-        <div className="mb-8 rounded-lg p-6 shadow-sm">
-          <h3 className="mb-3 font-bold text-xl lg:text-2xl">Course Length</h3>
-          <p className="text-gray-700">
-            Approximately 7 hours online, 25 hours in-person (including breaks)
-          </p>
-        </div>
-
-        {/* Course Preparation Section */}
-        <div className="mb-8 rounded-lg p-6 shadow-sm">
-          <h3 className="mb-3 font-bold text-xl lg:text-2xl">
-            Course Preparation
-          </h3>
-          <p className="mb-4 text-gray-700">
-            To prepare for the American Red Cross Lifeguarding course, please
-            ensure that you are 100% confident with the prerequisites listed
-            above. These will be conducted as soon as the course begins, and you
-            will not be able to continue in the course if you are unsuccessful.
-            In addition, be certain to complete the eLearning in its entirety
-            prior to the first in-person class session. This can take a while,
-            so please do not wait until the last minute to do this! The
-            eLearning is sent in the confirmation email following registration.
-            If you have any questions, please{" "}
-            <Link
-              className="font-medium text-primary hover:underline"
-              href="/contact"
-            >
-              contact us
-            </Link>
-            !
-          </p>
-        </div>
-
-        {/* Interested Section */}
-        <div className="mb-8 rounded-lg p-6 shadow-sm">
-          <h3 className="mb-3 font-bold text-xl lg:text-2xl">
-            Interested in taking a course?
-          </h3>
-          <p className="text-gray-700">
-            Search for open class on our{" "}
-            <Link
-              className="font-medium text-primary hover:underline"
-              href="https://www.hovn.app/tayloredinstruction"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              registration page
-            </Link>
-            !
-          </p>
-        </div>
-      </div>
-    </div>
+          .
+        </p>
+      </ClassPageSection>
+    </ClassPageLayout>
   );
-};
-
-export default LifeguardingPageContent;
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary
- Added a shared `ClassPageLayout` for course pages to unify hero treatment, CTA placement, resource links, and content spacing.
- Refactored the main class pages onto the shared layout so the Hovn registration action appears in the same place across the site.
- Tightened the registration CTA row so the secondary button no longer stretches larger than the primary button and both buttons align cleanly.

## Testing
- Lint and type-check passed.
- Verified the updated course pages locally in the browser to confirm the standardized layout and CTA alignment.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a shared `ClassPageLayout` component and refactors all eight course-page content components to use it, unifying hero imagery, the Hovn registration CTA card, resource link strips, and content spacing across the site.

- **`ClassPageLayout.tsx`** — New layout with a full-bleed hero, an overlapping CTA card (`-mt-14`), optional resource links, and optional secondary action buttons; all existing per-page markup is now replaced by this single component.
- **`CourseRegistrationButton.tsx`** — Updated to accept a `className` override, but the template-literal merge means the `mb-0` override passed by the layout does not reliably suppress the hardcoded `mb-12`.
- **Eight page-content components** — Each stripped of its bespoke hero/CTA markup and rewired to `ClassPageLayout` with course-specific props (`image`, `registrationUrl`, `resources`, `secondaryActions`, `subtitle`).

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the className merge in CourseRegistrationButton; without that fix the spacing change intended by this PR will silently not apply.

The refactor is clean and all eight page components migrate correctly. The one concrete defect is in CourseRegistrationButton: the mb-0 class passed from ClassPageLayout is merged via a plain template literal, so Tailwind cascade order lets mb-12 win — the extra bottom margin inside the CTA card is never removed, directly undermining the stated goal of tightened button alignment.

components/CourseRegistrationButton.tsx needs the className merge fixed before the layout change has its intended visual effect.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| components/ClassPageLayout.tsx | New shared layout component with hero, sticky CTA card, and resource links — well-structured, but the hardcoded "Certification Course" eyebrow text is inaccurate for the three instructor-training pages that also use this layout. |
| components/CourseRegistrationButton.tsx | className prop merged with a template literal instead of cn(), so the mb-0 override passed by ClassPageLayout will not win against the hardcoded mb-12 due to Tailwind cascade ordering — the intended spacing fix will not take effect. |
| components/AhaInstructorTrainingPageContent.tsx | Refactored to use ClassPageLayout; content preserved correctly with proper sections and registration URL. |
| components/BasicLifeSupportPageContent.tsx | Cleaned up and migrated to ClassPageLayout; resource links and content sections are intact. |
| components/BlsPageContent.tsx | Migrated to ClassPageLayout with correct AHA BLS registration URL and custom objectPosition value preserved. |
| components/FaCprAedInstructorPageContent.tsx | Migrated to ClassPageLayout; resource links and external Red Cross Learning Center link with noopener noreferrer are correct. |
| components/FirstAidCprAedPageContent.tsx | Refactored cleanly to ClassPageLayout; no regressions in content or registration URL. |
| components/HeartsaverPageContent.tsx | Migrated to ClassPageLayout with correct image position and AHA Heartsaver registration URL. |
| components/LifeguardingInstructorPageContent.tsx | Migrated to ClassPageLayout; correctly uses secondaryActions for the internal "Host This Course" CTA and subtitle prop. |
| components/LifeguardingPageContent.tsx | Migrated to ClassPageLayout; the external Hovn recertification secondary action and internal resource links are wired up correctly. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Course Page Route\ne.g. /bls] --> B[*PageContent Component]
    B --> C[ClassPageLayout]
    C --> D[Hero Section\nfull-bleed image + title]
    C --> E[CTA Card\n-mt-14 overlap]
    E --> F[CourseRegistrationButton\nHovn link + PostHog event]
    E --> G[secondaryActions\nButton list]
    E --> H[resources\nResourceLink list]
    C --> I[main content\nspace-y-8]
    I --> J[ClassPageSection\nborders + shadow card]
    J --> K[children JSX\nheadings, lists, FAQs]
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acomponents%2FCourseRegistrationButton.tsx%3A39%0AThe%20wrapper%20div%20builds%20its%20%60className%60%20with%20a%20template%20literal%2C%20so%20passing%20%60className%3D%22mb-0%22%60%20from%20%60ClassPageLayout%60%20produces%20%60%22mb-12%20text-center%20mb-0%22%60.%20Because%20Tailwind%20generates%20%60mb-0%60%20before%20%60mb-12%60%20in%20the%20stylesheet%20%28lower%20values%20come%20first%29%2C%20the%20cascade%20makes%20%60mb-12%60%20win%20regardless%20of%20HTML%20order%20%E2%80%94%20the%2048%20px%20bottom%20margin%20is%20never%20removed.%20Use%20the%20%60cn%28%29%60%20helper%20%28already%20available%20in%20%60lib%2Futils.ts%60%29%20so%20%60tailwind-merge%60%20can%20resolve%20the%20conflict%20correctly.%0A%0A%60%60%60suggestion%0A%20%20%20%20%3Cdiv%20className%3D%7Bcn%28%22mb-12%20text-center%22%2C%20className%29%7D%3E%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acomponents%2FClassPageLayout.tsx%3A78-80%0A**Hardcoded%20badge%20inaccurate%20for%20instructor%20pages**%0A%0AThe%20%22Certification%20Course%22%20eyebrow%20label%20is%20shown%20on%20all%20eight%20pages%20that%20use%20this%20layout%2C%20but%20three%20of%20them%20%E2%80%94%20AHA%20Instructor%20Training%2C%20FA%2FCPR%2FAED%20Instructor%2C%20and%20Lifeguarding%20Instructor%20%E2%80%94%20are%20instructor-training%20programmes%2C%20not%20participant%20certification%20courses.%20Consider%20adding%20an%20optional%20%60badgeLabel%60%20prop%20%28defaulting%20to%20%60%22Certification%20Course%22%60%29%20so%20instructor%20pages%20can%20pass%20something%20like%20%60%22Instructor%20Training%22%60%20instead.%0A%0A&pr=65&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
components/CourseRegistrationButton.tsx:39
The wrapper div builds its `className` with a template literal, so passing `className="mb-0"` from `ClassPageLayout` produces `"mb-12 text-center mb-0"`. Because Tailwind generates `mb-0` before `mb-12` in the stylesheet (lower values come first), the cascade makes `mb-12` win regardless of HTML order — the 48 px bottom margin is never removed. Use the `cn()` helper (already available in `lib/utils.ts`) so `tailwind-merge` can resolve the conflict correctly.

```suggestion
    <div className={cn("mb-12 text-center", className)}>
```

### Issue 2 of 2
components/ClassPageLayout.tsx:78-80
**Hardcoded badge inaccurate for instructor pages**

The "Certification Course" eyebrow label is shown on all eight pages that use this layout, but three of them — AHA Instructor Training, FA/CPR/AED Instructor, and Lifeguarding Instructor — are instructor-training programmes, not participant certification courses. Consider adding an optional `badgeLabel` prop (defaulting to `"Certification Course"`) so instructor pages can pass something like `"Instructor Training"` instead.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Standardize class page CTA layout"](https://github.com/evan-taylor/taylored-instruction/commit/3e165eaf062ede22d3ac318303bee147ac1b1445) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31456411)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->