### PR TITLE
Fix lifeguarding hero image crop

### DIFF
--- a/components/LifeguardingPageContent.tsx
+++ b/components/LifeguardingPageContent.tsx
@@ -9,7 +9,8 @@ export default function LifeguardingPageContent() {
       courseName="Lifeguarding"
       image={{
         alt: "Lifeguarding training session",
-        src: "/IMG_1872.jpeg",
+        position: "center 42%",
+        src: "/lifeguard-training.jpeg",
       }}
       registrationUrl="https://www.hovn.app/tayloredinstruction/courses/arc-lifeguarding-blended"
       resources={[
@@ -49,7 +50,9 @@ export default function LifeguardingPageContent() {
             <h3 className="mb-2 font-semibold text-gray-950 text-lg">
               Swim-Tread-Swim Sequence
             </h3>
-            <p className="mb-2 text-sm">Complete this sequence within 1 minute, 40 seconds:</p>
+            <p className="mb-2 text-sm">
+              Complete this sequence within 1 minute, 40 seconds:
+            </p>
             <ol className="list-decimal space-y-2 pl-5 text-sm">
               <li>
                 Jump into the water, fully submerge, resurface, then swim 150


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the hero image crop on the Lifeguarding page by replacing the old image file with a better-named one and setting a custom `objectPosition` to keep the subject centered at the desired vertical offset.

- Replaces `/IMG_1872.jpeg` with `/lifeguard-training.jpeg` (file exists in `public/`) and passes `position: \"center 42%\"` to `ClassPageLayout`, which applies it via `objectPosition` on the Next.js `<Image>`.
- Minor formatting cleanup: a single-line `<p>` tag is split across multiple lines for JSX consistency.

<h3>Confidence Score: 5/5</h3>

Safe to merge — a targeted visual fix with no logic changes.

The change swaps the hero image file (confirmed present in `public/`) and sets an `objectPosition` value already supported by `ClassPageLayout`. No logic, data flow, or API surface is touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| components/LifeguardingPageContent.tsx | Swaps the hero image src to `lifeguard-training.jpeg` (file confirmed in `public/`), adds `position: "center 42%"` to fine-tune vertical crop, and reformats one paragraph for consistent JSX style. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix lifeguarding hero image crop"](https://github.com/evan-taylor/taylored-instruction/commit/f779b62f7e4cee92e67df921f1b4cef358c7345e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31457934)</sub>

<!-- /greptile_comment -->