### PR TITLE
Add Google Business profile link

### DIFF
--- a/app/(marketing)/blog/[slug]/page.tsx
+++ b/app/(marketing)/blog/[slug]/page.tsx
@@ -25,6 +25,7 @@ type BlogPostPageProps = {
 
 const heroImageWidth = 1200;
 const heroImageHeight = 675;
+const emptyBlogStaticParamsSlug = "__empty-blog-static-param__";
 
 const formatPublishedDate = (date: string) =>
   new Date(date).toLocaleDateString("en-US", {
@@ -106,6 +107,10 @@ export async function generateStaticParams() {
     tags: ["post"],
   }).catch(() => []);
 
+  if (posts.length === 0) {
+    return [{ slug: emptyBlogStaticParamsSlug }];
+  }
+
   return posts.map((post) => ({ slug: post.slug }));
 }
 
@@ -163,6 +168,10 @@ export default async function BlogPostPage(props: BlogPostPageProps) {
   cacheTag("post");
 
   const params = await props.params;
+  if (params.slug === emptyBlogStaticParamsSlug) {
+    notFound();
+  }
+
   cacheTag(`post:${params.slug}`);
   const post = await getPost(params.slug);
 

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -1,5 +1,6 @@
 import { Facebook, Instagram } from "lucide-react";
 import Link from "next/link";
+import { GOOGLE_BUSINESS_PROFILE_URL } from "@/lib/businessProfile";
 
 export const Footer = () => {
   return (
@@ -82,6 +83,16 @@ export const Footer = () => {
                   href="tel:3606588199"
                 >
                   (360) 658-8199
+                </a>
+              </li>
+              <li>
+                <a
+                  className="transition-colors hover:text-primary"
+                  href={GOOGLE_BUSINESS_PROFILE_URL}
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Taylored Instruction on Google
                 </a>
               </li>
             </ul>

--- a/lib/businessProfile.ts
+++ b/lib/businessProfile.ts
@@ -1,0 +1,2 @@
+export const GOOGLE_BUSINESS_PROFILE_URL =
+  "https://share.google/7PSi0Vq65i7nMgHnI";

--- a/lib/structuredData.ts
+++ b/lib/structuredData.ts
@@ -2,6 +2,8 @@
  * Structured Data (JSON-LD) for SEO
  * Comprehensive schema markup for Taylored Instruction
  */
+
+import { GOOGLE_BUSINESS_PROFILE_URL } from "@/lib/businessProfile";
 import { SITE_URL } from "@/lib/seo";
 
 type LocalBusinessSchema = {
@@ -243,10 +245,7 @@ export const getOrganizationSchema = (): OrganizationSchema => ({
     name: "Evan Taylor",
     jobTitle: "Instructor Trainer, Owner",
   },
-  sameAs: [
-    // Add social media links when available
-    "https://tayloredinstruction.com",
-  ],
+  sameAs: ["https://tayloredinstruction.com", GOOGLE_BUSINESS_PROFILE_URL],
   knowsAbout: [
     "CPR Training",
     "BLS Certification",
@@ -305,7 +304,7 @@ export const getVancouverLocalBusinessSchema = (): LocalBusinessSchema => ({
       "Sunday",
     ],
   },
-  sameAs: ["https://tayloredinstruction.com"],
+  sameAs: ["https://tayloredinstruction.com", GOOGLE_BUSINESS_PROFILE_URL],
 });
 
 // Local Business Schema - San Luis Obispo, CA
@@ -352,7 +351,7 @@ export const getSLOLocalBusinessSchema = (): LocalBusinessSchema => ({
       "Sunday",
     ],
   },
-  sameAs: ["https://tayloredinstruction.com"],
+  sameAs: ["https://tayloredinstruction.com", GOOGLE_BUSINESS_PROFILE_URL],
 });
 
 // Website Schema


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a shared Google Business Profile URL constant.
- Add a visible footer link to Taylored Instruction on Google.
- Include the Google Business Profile URL in organization and local business JSON-LD `sameAs` data.
- Fix the Next.js Cache Components build failure for `/blog/[slug]` when Sanity has no published blog posts by returning a validation placeholder static param and routing that placeholder to `notFound()`.

## Testing
- `bun run test`
- `NEXT_PUBLIC_SANITY_PROJECT_ID=demo bun run build`
- Verified rendered HTML contains the Google Business anchor with `target="_blank"` and `rel="noopener noreferrer"`.
- Verified rendered JSON-LD includes the Google Business URL, and the external target resolves with HTTP 200 to `www.google.com`.

## Notes
- `baseline-browser-mapping@latest` currently resolves to `2.10.31`, which is already the installed/latest npm version, so the warning remains upstream/package-data related rather than a repo dependency drift.

## Walkthrough
[google_business_footer_link.mp4](https://cursor.com/agents/bc-59376f4c-7dda-5307-a63b-ee586a6aa428/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgoogle_business_footer_link.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://taylor-labs.slack.com/archives/D0AGXQRT5RD/p1779302715570739?thread_ts=1779302715.570739&cid=D0AGXQRT5RD)

<div><a href="https://cursor.com/agents/bc-59376f4c-7dda-5307-a63b-ee586a6aa428"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-59376f4c-7dda-5307-a63b-ee586a6aa428"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

