### PR TITLE
Load app secrets from Infisical

### DIFF
--- a/.infisical.json
+++ b/.infisical.json
@@ -1,0 +1,5 @@
+{
+  "workspaceId": "5981bad0-a496-4ffd-96c6-4e9024025be2",
+  "defaultEnvironment": "dev",
+  "gitBranchToEnvironmentMapping": null
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -351,6 +351,8 @@ Set `INFISICAL_ENV` to `dev` (default), `staging`, or `prod`. Hosts that already
 
 The Convex client provider still throws if `NEXT_PUBLIC_CONVEX_URL` is missing after injection. Do not copy Infisical machine-identity credentials into Infisical itself.
 
+Sanity, Notion, Stripe publishable, and other app vars that were never in Cloud Agent secrets are not in Infisical yet. Add them in the Infisical dashboard if a command needs them.
+
 ### Lint / Type-check / Test
 
 - `bun run lint` — runs `bunx ultracite check` (Biome-based)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -335,10 +335,21 @@ This is a Next.js 16 website (Taylored Instruction — CPR/BLS training company)
 ### Running the dev server
 
 ```bash
-bun run dev          # starts Next.js on port 3000
+bun run dev          # starts Next.js on port 3000 with Infisical-injected secrets
+bun run build        # production build with Infisical-injected secrets
+bun run env:pull     # optional: write Infisical secrets to .env.local
 ```
 
-A `.env.local` file must exist with at least `NEXT_PUBLIC_CONVEX_URL` set — the Convex client provider throws at module load time if it is missing. All available VM secrets must be written to `.env.local` before starting the dev server. Key vars: `NEXT_PUBLIC_CONVEX_URL`, `CONVEX_DEPLOYMENT`, `STRIPE_SECRET_KEY`, `RESEND_API_KEY`, `NEXT_PUBLIC_BASE_URL`, `SENTRY_AUTH_TOKEN`, `NEXT_PUBLIC_POSTHOG_KEY`, `NEXT_PUBLIC_POSTHOG_HOST`, `AUTH_GOOGLE_ID`, `AUTH_GOOGLE_SECRET`, `AUTH_EMAIL_FROM`, `JWKS`, `JWT_PRIVATE_KEY`, `SITE_URL`, `INTERNAL_EMAIL_WEBHOOK_SECRET`.
+App secrets live in the Infisical project **Taylored Instruction** (see `.infisical.json`). `dev` / `build` / `start` wrap the Next.js command with `infisical run` via `scripts/with-infisical.sh`.
+
+Authenticate with one of:
+- `INFISICAL_CLIENT_ID` + `INFISICAL_CLIENT_SECRET` (Cloud Agent / CI machine identity)
+- `INFISICAL_TOKEN`
+- `infisical login` (local interactive session)
+
+Set `INFISICAL_ENV` to `dev` (default), `staging`, or `prod`. Hosts that already inject app env (for example Vercel) fall back to running Next.js without the CLI.
+
+The Convex client provider still throws if `NEXT_PUBLIC_CONVEX_URL` is missing after injection. Do not copy Infisical machine-identity credentials into Infisical itself.
 
 ### Lint / Type-check / Test
 

--- a/bun.lock
+++ b/bun.lock
@@ -50,6 +50,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^2.2.4",
+        "@infisical/cli": "^0.43.123",
         "@types/node": "^20.10.0",
         "@types/react": "^19.2.2",
         "@types/react-dom": "^19.2.2",
@@ -562,6 +563,8 @@
     "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.4", "", { "os": "win32", "cpu": "ia32" }, "sha512-3ZeLue5V82dT92CNL6rsal6I2weKw1cYu+rGKm8fOCCtJTR2gYeUfY3FqUnIJsMUPIH68oS5jmZ0NiJ508YpEw=="],
 
     "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.4", "", { "os": "win32", "cpu": "x64" }, "sha512-xIyj4wpYs8J18sVN3mSQjwrw7fKUqRw+Z5rnHNCy5fYTxigBz81u5mOMPmFumwjcn8+ld1ppptMBCLic1nz6ig=="],
+
+    "@infisical/cli": ["@infisical/cli@0.43.123", "", { "dependencies": { "tar": "^7.5.13", "yauzl": "^3.2.0" }, "bin": { "infisical": "bin/infisical" } }, "sha512-43zCT7wGgFb/YzOlZm3o+NDYpf3Kp2l7HBS0HWfKcqwsqhK7GZF5csyEqS0wjkjQgY/Q10M/sjBccVcAmkx+Dg=="],
 
     "@inquirer/ansi": ["@inquirer/ansi@1.0.2", "", {}, "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ=="],
 
@@ -2397,6 +2400,8 @@
 
     "peek-stream": ["peek-stream@1.1.3", "", { "dependencies": { "buffer-from": "^1.0.0", "duplexify": "^3.5.0", "through2": "^2.0.3" } }, "sha512-FhJ+YbOSBb9/rIl2ZeE/QHEsWn7PqNYt8ARAY3kIgNGOk13g9FGyIY6JIl/xB/3TFRVoTv5as0l11weORrTekA=="],
 
+    "pend": ["pend@1.2.0", "", {}, "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="],
+
     "performance-now": ["performance-now@2.1.0", "", {}, "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="],
 
     "pg-int8": ["pg-int8@1.0.1", "", {}, "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="],
@@ -2939,6 +2944,8 @@
 
     "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
+    "yauzl": ["yauzl@3.4.0", "", { "dependencies": { "pend": "~1.2.0" } }, "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw=="],
+
     "yjs": ["yjs@13.6.27", "", { "dependencies": { "lib0": "^0.2.99" } }, "sha512-OIDwaflOaq4wC6YlPBy2L6ceKeKuF7DeTxx+jPzv1FHn9tCZ0ZwSRnUBxD05E3yed46fv/FWJbvR+Ud7x0L7zw=="],
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
@@ -3163,7 +3170,7 @@
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
-    "fdir/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+    "fdir/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "filelist/minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
 

--- a/package.json
+++ b/package.json
@@ -7,9 +7,10 @@
     "node": ">=20.19 <22 || >=22.12"
   },
   "scripts": {
-    "dev": "next dev",
-    "build": "next build",
-    "start": "next start",
+    "dev": "bash scripts/with-infisical.sh next dev",
+    "build": "bash scripts/with-infisical.sh next build",
+    "start": "bash scripts/with-infisical.sh next start",
+    "env:pull": "bash scripts/with-infisical.sh --export > .env.local",
     "lint": "bunx ultracite check",
     "type-check": "tsc --noEmit",
     "test": "bun run lint && bun run type-check"
@@ -60,6 +61,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.2.4",
+    "@infisical/cli": "^0.43.123",
     "@types/node": "^20.10.0",
     "@types/react": "^19.2.2",
     "@types/react-dom": "^19.2.2",

--- a/scripts/with-infisical.sh
+++ b/scripts/with-infisical.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Inject Taylored Instruction secrets from Infisical, then run the given command.
+# Auth options (first match wins):
+#   1. INFISICAL_TOKEN
+#   2. INFISICAL_CLIENT_ID + INFISICAL_CLIENT_SECRET (universal-auth machine identity)
+#   3. An existing `infisical login` session
+# If Infisical is unavailable but the process already has app env (e.g. Vercel),
+# the command runs as-is.
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PROJECT_ID="${INFISICAL_PROJECT_ID:-5981bad0-a496-4ffd-96c6-4e9024025be2}"
+ENV_NAME="${INFISICAL_ENV:-dev}"
+export INFISICAL_DISABLE_UPDATE_CHECK="${INFISICAL_DISABLE_UPDATE_CHECK:-true}"
+
+find_infisical() {
+  if command -v infisical >/dev/null 2>&1; then
+    command -v infisical
+    return 0
+  fi
+  if [[ -x "$ROOT/node_modules/.bin/infisical" ]]; then
+    printf '%s\n' "$ROOT/node_modules/.bin/infisical"
+    return 0
+  fi
+  return 1
+}
+
+has_app_env() {
+  [[ -n "${NEXT_PUBLIC_CONVEX_URL:-}" ]]
+}
+
+run_without_infisical() {
+  exec "$@"
+}
+
+EXPORT_DOTENV=0
+if [[ "${1:-}" == "--export" ]]; then
+  EXPORT_DOTENV=1
+  shift
+fi
+
+if [[ $EXPORT_DOTENV -eq 0 && $# -eq 0 ]]; then
+  echo "usage: scripts/with-infisical.sh [--export] <command> [args...]" >&2
+  exit 1
+fi
+
+if ! INFISICAL_BIN="$(find_infisical)"; then
+  if [[ $EXPORT_DOTENV -eq 0 ]] && has_app_env; then
+    run_without_infisical "$@"
+  fi
+  echo "Infisical CLI is not installed. Install it from https://infisical.com/docs/cli/overview or run bun install." >&2
+  exit 1
+fi
+
+if [[ -z "${INFISICAL_TOKEN:-}" && -n "${INFISICAL_CLIENT_ID:-}" && -n "${INFISICAL_CLIENT_SECRET:-}" ]]; then
+  INFISICAL_TOKEN="$("$INFISICAL_BIN" login --method=universal-auth --client-id="$INFISICAL_CLIENT_ID" --client-secret="$INFISICAL_CLIENT_SECRET" --silent --plain)"
+  export INFISICAL_TOKEN
+fi
+
+if [[ -n "${INFISICAL_TOKEN:-}" ]] ||
+  "$INFISICAL_BIN" login status --silent >/dev/null 2>&1; then
+  if [[ $EXPORT_DOTENV -eq 1 ]]; then
+    exec "$INFISICAL_BIN" export --projectId="$PROJECT_ID" --env="$ENV_NAME" --format=dotenv --silent
+  fi
+  exec "$INFISICAL_BIN" run --projectId="$PROJECT_ID" --env="$ENV_NAME" --silent -- "$@"
+fi
+
+if [[ $EXPORT_DOTENV -eq 0 ]] && has_app_env; then
+  run_without_infisical "$@"
+fi
+
+echo "Authenticate with Infisical first: infisical login" >&2
+echo "Or set INFISICAL_CLIENT_ID and INFISICAL_CLIENT_SECRET." >&2
+exit 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Moves Taylored Instruction app secrets into the new Infisical project and wraps `dev` / `build` / `start` so they inject those secrets at runtime.

## Infisical
- Project: **Taylored Instruction** (`taylored-instruction-ql-wb`)
- Linked in-repo via `.infisical.json`
- Uploaded the 17 Cloud Agent app secrets into `dev`, `staging`, and `prod`
- Did **not** copy `INFISICAL_CLIENT_ID` / `INFISICAL_CLIENT_SECRET` into Infisical (those stay in Cursor Cloud / CI to authenticate)

### Secrets migrated
`ADMIN_EMAIL_RECIPIENT`, `ADMIN_NOTIF_EMAIL`, `AUTH_EMAIL_FROM`, `AUTH_GOOGLE_ID`, `AUTH_GOOGLE_SECRET`, `CONVEX_DEPLOYMENT`, `INTERNAL_EMAIL_WEBHOOK_SECRET`, `JWKS`, `JWT_PRIVATE_KEY`, `NEXT_PUBLIC_BASE_URL`, `NEXT_PUBLIC_CONVEX_URL`, `NEXT_PUBLIC_POSTHOG_HOST`, `NEXT_PUBLIC_POSTHOG_KEY`, `RESEND_API_KEY`, `SENTRY_AUTH_TOKEN`, `SITE_URL`, `STRIPE_SECRET_KEY`

## Scripts
- `bun run dev` / `build` / `start` now run through `scripts/with-infisical.sh`
- `bun run env:pull` writes Infisical secrets to `.env.local` when a file is needed
- Auth: machine identity (`INFISICAL_CLIENT_ID` + `INFISICAL_CLIENT_SECRET`), `INFISICAL_TOKEN`, or `infisical login`
- Vercel and other hosts that already inject app env fall back to running Next.js without the CLI

## Verification
- Injected Infisical values match the original Cloud Agent secrets (hashed compare)
- `bun run lint` and `bun run type-check` pass
- `bun run build` compiles with Infisical injection (`Injecting 17 Infisical secrets`)
- Page-data collection then fails on `NEXT_PUBLIC_SANITY_PROJECT_ID`, which was never a Cloud Agent secret and is not in Infisical yet

## Follow-up
After this lands, Cloud Agent only needs `INFISICAL_CLIENT_ID` and `INFISICAL_CLIENT_SECRET`. The other dashboard secrets can be removed once you are comfortable pulling from Infisical. Add Sanity/Notion/publishable Stripe vars in Infisical if you want those to come from there too.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e8a1c8f-9627-42a8-9ffe-1e8f9a10a826?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e8a1c8f-9627-42a8-9ffe-1e8f9a10a826&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds Infisical-backed lifecycle commands and a command for exporting secrets into `.env.local`. Two reproduced reliability failures need attention before merge: `env:pull` can erase an existing local environment file when export fails, and a failed universal-auth login prevents the wrapper from using already injected application configuration.

<h3>Confidence Score: 3/5</h3>

Not safe to merge until failed exports preserve existing local configuration and failed machine authentication can fall back to already injected application environment values.

Both reported failures were reproduced with isolated executions of the production wrapper and controlled Infisical command failures. One test demonstrated that a failed export empties a populated destination file; the other demonstrated that a failed universal-auth login exits before the documented fallback executes.

**Files Needing Attention:** `package.json` needs a non-destructive export workflow, and `scripts/with-infisical.sh` needs explicit handling for universal-auth login failure before evaluating the existing environment fallback.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Wrote the isolated Infisical export truncation validation script to simulate a failing export and verify truncation without touching repository files.
- Executed the truncation validation script and captured its execution output, supporting the truncation assertion.
- Compared the preexisting isolated environment state before the export and observed the isolated export failure.
- Authored a fake Infisical validation script to exercise the universal-auth fallback path and observed the wrapper exit after login failure and the injected app-environment fallback.
- Wrote and ran the universal-auth fallback validation workflow and captured before/after logs to verify the guarded fallback path without modifying repository.

<a href="https://app.greptile.com/trex/runs/19956590/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Failed env:pull can erase an existing .env.local**

   - **Bug**
     - `package.json:13` redirects the wrapper's standard output directly to `.env.local`. POSIX shell redirection opens and truncates that file before `scripts/with-infisical.sh` runs Infisical. The isolated execution seeded a 31-byte env file, simulated an `infisical export` failure (exit 42), and found the output file empty afterward.
   - **Cause**
     - The `> .env.local` redirection is performed by the invoking shell before the wrapper can report an unsuccessful export.
   - **Fix**
     - Export to a temporary file and atomically replace `.env.local` only after the wrapper exits successfully, for example `tmp=$(mktemp .env.local.XXXXXX) && bash scripts/with-infisical.sh --export > "$tmp" && mv "$tmp" .env.local`; ensure cleanup of the temporary file on failure.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>


2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Universal-auth failure bypasses injected app-environment fallback**

   - **Bug**
     - When no `INFISICAL_TOKEN` is set but machine credentials are set, a failed universal-auth login causes the wrapper to exit immediately. This prevents the later `NEXT_PUBLIC_CONVEX_URL` fallback from running the requested command.
   - **Cause**
     - The line-57 command-substitution assignment returns the fake CLI's nonzero status (23). Because the script enables `set -e` at line 2 and the assignment is not in an error-handling conditional, Bash exits before lines 69-70.
   - **Fix**
     - Handle the universal-auth assignment failure explicitly (for example, place it in an `if` condition), leave `INFISICAL_TOKEN` unset on failure, and permit the existing direct injected-app-env fallback to execute when `NEXT_PUBLIC_CONVEX_URL` is present.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22evan-taylor%2Ftaylored-instruction%22%20on%20the%20existing%20branch%20%22evan%2Finfisical-secrets-a826%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22evan%2Finfisical-secrets-a826%22.%0A%0AGreploop%20evan-taylor%2Ftaylored-instruction%20PR%20%2376%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=evan-taylor%2Ftaylored-instruction"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22evan-taylor%2Ftaylored-instruction%22%20on%20the%20existing%20branch%20%22evan%2Finfisical-secrets-a826%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22evan%2Finfisical-secrets-a826%22.%0A%0A%23%23%23%20Issue%201%0Apackage.json%3A13%0A**Failed%20export%20erases%20the%20local%20environment%20file**%0A%0A%60env%3Apull%60%20redirects%20the%20wrapper%20output%20directly%20into%20%60.env.local%60%2C%20so%20the%20shell%20truncates%20an%20existing%20file%20before%20Infisical%20runs.%20A%20failed%20export%20therefore%20leaves%20developers%20without%20the%20local-only%20variables%20that%20were%20previously%20present.%20Write%20to%20a%20temporary%20file%20and%20replace%20%60.env.local%60%20only%20after%20the%20export%20succeeds.%0A%0A%23%23%23%20Issue%202%0Ascripts%2Fwith-infisical.sh%3A56-58%0A**Universal-auth%20failure%20skips%20the%20direct-environment%20fallback**%0A%0AWhen%20machine%20credentials%20are%20present%20but%20universal-auth%20login%20fails%2C%20the%20unguarded%20token%20assignment%20exits%20under%20%60set%20-e%60%20before%20the%20later%20%60NEXT_PUBLIC_CONVEX_URL%60%20fallback%20can%20run%20the%20requested%20command.%20This%20makes%20%60dev%60%2C%20%60build%60%2C%20and%20%60start%60%20fail%20in%20hosts%20that%20already%20inject%20application%20configuration%20but%20have%20invalid%2C%20expired%2C%20or%20unreachable%20Infisical%20credentials.%20Handle%20the%20login%20failure%20explicitly%20and%20then%20allow%20the%20existing%20fallback%20to%20run%20when%20application%20environment%20values%20are%20available.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=evan-taylor%2Ftaylored-instruction"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Apackage.json%3A13%0A**Failed%20export%20erases%20the%20local%20environment%20file**%0A%0A%60env%3Apull%60%20redirects%20the%20wrapper%20output%20directly%20into%20%60.env.local%60%2C%20so%20the%20shell%20truncates%20an%20existing%20file%20before%20Infisical%20runs.%20A%20failed%20export%20therefore%20leaves%20developers%20without%20the%20local-only%20variables%20that%20were%20previously%20present.%20Write%20to%20a%20temporary%20file%20and%20replace%20%60.env.local%60%20only%20after%20the%20export%20succeeds.%0A%0A%23%23%23%20Issue%202%0Ascripts%2Fwith-infisical.sh%3A56-58%0A**Universal-auth%20failure%20skips%20the%20direct-environment%20fallback**%0A%0AWhen%20machine%20credentials%20are%20present%20but%20universal-auth%20login%20fails%2C%20the%20unguarded%20token%20assignment%20exits%20under%20%60set%20-e%60%20before%20the%20later%20%60NEXT_PUBLIC_CONVEX_URL%60%20fallback%20can%20run%20the%20requested%20command.%20This%20makes%20%60dev%60%2C%20%60build%60%2C%20and%20%60start%60%20fail%20in%20hosts%20that%20already%20inject%20application%20configuration%20but%20have%20invalid%2C%20expired%2C%20or%20unreachable%20Infisical%20credentials.%20Handle%20the%20login%20failure%20explicitly%20and%20then%20allow%20the%20existing%20fallback%20to%20run%20when%20application%20environment%20values%20are%20available.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=76&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22evan-taylor%2Ftaylored-instruction%22%20on%20the%20existing%20branch%20%22evan%2Finfisical-secrets-a826%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22evan%2Finfisical-secrets-a826%22.%0A%0A%23%23%23%20Issue%201%0Apackage.json%3A13%0A**Failed%20export%20erases%20the%20local%20environment%20file**%0A%0A%60env%3Apull%60%20redirects%20the%20wrapper%20output%20directly%20into%20%60.env.local%60%2C%20so%20the%20shell%20truncates%20an%20existing%20file%20before%20Infisical%20runs.%20A%20failed%20export%20therefore%20leaves%20developers%20without%20the%20local-only%20variables%20that%20were%20previously%20present.%20Write%20to%20a%20temporary%20file%20and%20replace%20%60.env.local%60%20only%20after%20the%20export%20succeeds.%0A%0A%23%23%23%20Issue%202%0Ascripts%2Fwith-infisical.sh%3A56-58%0A**Universal-auth%20failure%20skips%20the%20direct-environment%20fallback**%0A%0AWhen%20machine%20credentials%20are%20present%20but%20universal-auth%20login%20fails%2C%20the%20unguarded%20token%20assignment%20exits%20under%20%60set%20-e%60%20before%20the%20later%20%60NEXT_PUBLIC_CONVEX_URL%60%20fallback%20can%20run%20the%20requested%20command.%20This%20makes%20%60dev%60%2C%20%60build%60%2C%20and%20%60start%60%20fail%20in%20hosts%20that%20already%20inject%20application%20configuration%20but%20have%20invalid%2C%20expired%2C%20or%20unreachable%20Infisical%20credentials.%20Handle%20the%20login%20failure%20explicitly%20and%20then%20allow%20the%20existing%20fallback%20to%20run%20when%20application%20environment%20values%20are%20available.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=evan-taylor%2Ftaylored-instruction&pr=76&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
package.json:13
**Failed export erases the local environment file**

`env:pull` redirects the wrapper output directly into `.env.local`, so the shell truncates an existing file before Infisical runs. A failed export therefore leaves developers without the local-only variables that were previously present. Write to a temporary file and replace `.env.local` only after the export succeeds.

### Issue 2
scripts/with-infisical.sh:56-58
**Universal-auth failure skips the direct-environment fallback**

When machine credentials are present but universal-auth login fails, the unguarded token assignment exits under `set -e` before the later `NEXT_PUBLIC_CONVEX_URL` fallback can run the requested command. This makes `dev`, `build`, and `start` fail in hosts that already inject application configuration but have invalid, expired, or unreachable Infisical credentials. Handle the login failure explicitly and then allow the existing fallback to run when application environment values are available.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Note that Sanity and other unused Cloud ..."](https://github.com/evan-taylor/taylored-instruction/commit/44197aecc1ae549476aed1f7fbc6705c91069cf3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55442228)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->